### PR TITLE
Don't pass --no-as-needed to ld on Mac

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -476,7 +476,8 @@ class BuildExt(build_ext):
       self.compiler.linker_so.extend(
         ["-Wl,-rpath", os.path.join(JAVA_HOME, 'jre/lib/server')]
         )
-    self.compiler.linker_so.append("-Wl,--no-as-needed")
+    else:
+      self.compiler.linker_so.append("-Wl,--no-as-needed")
     build_ext.build_extension(self, ext)
 
   def run(self):


### PR DESCRIPTION
Compiling pydoop against hadoop 1.2.1 on Mac OS X 10.9.4 fails (the flag is unrecognised).
