### PR TITLE
Add paths for hadoop-1.2.1-1 on CentOS6

### DIFF
--- a/pydoop/hadoop_utils.py
+++ b/pydoop/hadoop_utils.py
@@ -424,7 +424,9 @@ class PathFinder(object):
         else:
           self.__hadoop_classpath = ':'.join(
             glob.glob(os.path.join(hadoop_home, 'hadoop*.jar')) +
-            glob.glob(os.path.join(hadoop_home, 'lib', '*.jar'))
+            glob.glob(os.path.join(hadoop_home, 'lib', '*.jar')) +
+            glob.glob(os.path.join(hadoop_home, 'share/hadoop', '*.jar')) +
+            glob.glob(os.path.join(hadoop_home, 'share/hadoop/lib', '*.jar'))
             )
       else:  # FIXME: this does not cover from-tarball installation
         mr1_home = "%s-0.20-mapreduce" % hadoop_home


### PR DESCRIPTION
I'm not sure if this is PR is appropriate or not.

I'm using an official hadoop-1.2.1 rpm from http://www.mirrorservice.org/sites/ftp.apache.org/hadoop/common/hadoop-1.2.1/hadoop-1.2.1-1.x86_64.rpm

and the paths to the hadoop jars aren't detected by pydoop:

```
/usr/share/hadoop/
/usr/share/hadoop/lib
```
