### PR TITLE
Fix OSX compile errors/warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -476,7 +476,7 @@ class BuildExt(build_ext):
       self.compiler.linker_so.extend(
         ["-Wl,-rpath", os.path.join(JAVA_HOME, 'jre/lib/server')]
         )
-    self.compiler.linker_so.append("-Wl,--no-as-needed")
+    self.compiler.linker_so.append("-Wl")
     build_ext.build_extension(self, ext)
 
   def run(self):

--- a/src/hadoop-2.0.0-cdh4.3.0/libhdfs/hdfs.c
+++ b/src/hadoop-2.0.0-cdh4.3.0/libhdfs/hdfs.c
@@ -2730,24 +2730,24 @@ hdfsFileInfo *hdfsGetPathInfo(hdfsFS fs, const char* path)
     return fileInfo;
 }
 
-static void hdfsFreeFileInfoEntry(hdfsFileInfo *hdfsFileInfo)
+static void hdfsFreeFileInfoEntry(hdfsFileInfo *hfi)
 {
-    free(hdfsFileInfo->mName);
-    free(hdfsFileInfo->mOwner);
-    free(hdfsFileInfo->mGroup);
-    memset(hdfsFileInfo, 0, sizeof(hdfsFileInfo));
+    free(hfi->mName);
+    free(hfi->mOwner);
+    free(hfi->mGroup);
+    memset(hfi, 0, sizeof(hdfsFileInfo));
 }
 
-void hdfsFreeFileInfo(hdfsFileInfo *hdfsFileInfo, int numEntries)
+void hdfsFreeFileInfo(hdfsFileInfo *hfi, int numEntries)
 {
     //Free the mName, mOwner, and mGroup
     int i;
     for (i=0; i < numEntries; ++i) {
-        hdfsFreeFileInfoEntry(hdfsFileInfo + i);
+        hdfsFreeFileInfoEntry(hfi + i);
     }
 
     //Free entire block
-    free(hdfsFileInfo);
+    free(hfi);
 }
 
 

--- a/src/hadoop-2.2.0/libhdfs/hdfs.c
+++ b/src/hadoop-2.2.0/libhdfs/hdfs.c
@@ -2730,24 +2730,24 @@ hdfsFileInfo *hdfsGetPathInfo(hdfsFS fs, const char* path)
     return fileInfo;
 }
 
-static void hdfsFreeFileInfoEntry(hdfsFileInfo *hdfsFileInfo)
+static void hdfsFreeFileInfoEntry(hdfsFileInfo *hfi)
 {
-    free(hdfsFileInfo->mName);
-    free(hdfsFileInfo->mOwner);
-    free(hdfsFileInfo->mGroup);
-    memset(hdfsFileInfo, 0, sizeof(hdfsFileInfo));
+    free(hfi->mName);
+    free(hfi->mOwner);
+    free(hfi->mGroup);
+    memset(hfi, 0, sizeof(hdfsFileInfo));
 }
 
-void hdfsFreeFileInfo(hdfsFileInfo *hdfsFileInfo, int numEntries)
+void hdfsFreeFileInfo(hdfsFileInfo *hfi, int numEntries)
 {
     //Free the mName, mOwner, and mGroup
     int i;
     for (i=0; i < numEntries; ++i) {
-        hdfsFreeFileInfoEntry(hdfsFileInfo + i);
+        hdfsFreeFileInfoEntry(hfi + i);
     }
 
     //Free entire block
-    free(hdfsFileInfo);
+    free(hfi);
 }
 
 

--- a/src/hdfs_file.cpp
+++ b/src/hdfs_file.cpp
@@ -53,7 +53,7 @@ tSize wrap_hdfs_file::read_chunk(bp::object buffer) {
   PyObject *pyo = buffer.ptr();
   void *buf;
   Py_ssize_t len;
-  if (PyObject_AsWriteBuffer(buffer.ptr(), &buf, &len)) {
+  if (PyObject_AsWriteBuffer(pyo, &buf, &len)) {
     throw hdfs_exception("Cannot read_chunk on" + filename_);
   }
   exec_and_trap_error(tSize,


### PR DESCRIPTION
I just tried installing from source on OSX 10.9.4 and it failed with various errors and warnings. This should fix it. Though there was still a warning about tOffset (long long *) not matching jlong (long *):

    src/hadoop-2.4.0.patched/libhdfs/hdfs.c:2331:49: warning: incompatible pointer types passing 'tOffset *' (aka 'long long *') to parameter of type 'jlong *' (aka 'long *')
          [-Wincompatible-pointer-types]
        jthr = getDefaultBlockSize(env, jFS, jPath, &blockSize);
                                                    ^~~~~~~~~~
    src/hadoop-2.4.0.patched/libhdfs/hdfs.c:787:61: note: passing argument to parameter 'out' here
                                          jobject jPath, jlong *out)
                                                                ^
    1 warning generated.

Unfortunately I couldn't figure out how that patched code was generated in order to fix it. In all the hdfs.c files in the source repo, it looked like the pointer types agreed with each other.