### PR TITLE
Fix the jpype hdfs backend with Hadoop 1.0.4

### DIFF
--- a/pydoop/hdfs/core/bridged/hadoop.py
+++ b/pydoop/hdfs/core/bridged/hadoop.py
@@ -246,7 +246,7 @@ class CoreHdfsFs(CoreFsApi):
             else:
                 boolean_overwrite = True
                 if not blocksize:
-                    blocksize = self._fs.getDefaultBlockSize(jpath)
+                    blocksize = self.get_default_block_size()
                 stream = self._fs.create(
                     jpath, boolean_overwrite, buff_size, replication, blocksize
                 )


### PR DESCRIPTION
hadoop.open_file was using the FileSystem.getDefaultBlockSize(path) method which takes 0 argument in Hadoop 1.0.4
