### PR TITLE
Change submit args

### DIFF
--- a/examples/avro/py/run_py_only_map_reduce.sh
+++ b/examples/avro/py/run_py_only_map_reduce.sh
@@ -30,7 +30,6 @@ ${SUBMIT_CMD} --python-egg ${MZIP} --upload-to-cache ${AVRO_STATS_AVSC} \
                                    --upload-to-cache ${AVRO_USER_AVSC} \
               -D mapreduce.pipes.isjavarecordreader=false \
               -D mapreduce.pipes.isjavarecordwriter=false \
-              --module ${MODULE} \
               --log-level ${LOGLEVEL} ${MRV} --job-name ${JOBNAME} \
-              ${PROGNAME} ${INPUT} ${OUTPUT} 
+              ${MODULE} ${INPUT} ${OUTPUT}
 

--- a/examples/input_format/Makefile
+++ b/examples/input_format/Makefile
@@ -20,11 +20,10 @@ PYINPUTFORMAT_JAR=pydoop-input-formats.jar
 INPUT_FORMAT_MRV1=it.crs4.pydoop.mapred.TextInputFormat
 INPUT_FORMAT_MRV2=it.crs4.pydoop.mapreduce.TextInputFormat
 LOGLEVEL=INFO
-PROGNAME=input_format_test
 JOBNAME=input_format_test_job
 DATA := ../input
-INPUT=${PROGNAME}_input
-OUTPUT=${PROGNAME}_output
+INPUT=${JOBNAME}_input
+OUTPUT=${JOBNAME}_output
 
 pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
 SUBMIT_CMD=pydoop submit
@@ -46,8 +45,8 @@ SRC = $(wildcard it/crs4/pydoop/mapred*/TextInputFormat.java)
 CLASSES = $(subst .java,.class,$(SRC))
 
 SUBMIT_ARGS = --upload-file-to-cache wordcount_rr.py \
+wordcount_rr \
 --libjars ${PYINPUTFORMAT_JAR}\
---module wordcount_rr\
 --do-not-use-java-record-reader\
 -D pydoop.input.issplitable=true\
 --log-level ${LOGLEVEL} --job-name ${JOBNAME}
@@ -76,13 +75,13 @@ data:
 
 submit_mrv1: data ${PYINPUTFORMAT_JAR}
 	${SUBMIT_CMD} ${SUBMIT_ARGS} --input-format ${INPUT_FORMAT_MRV1}\
-		            ${PROGNAME} ${INPUT} ${OUTPUT}_MRV1
+		            ${INPUT} ${OUTPUT}_MRV1
 	python check_results.py ${DATA} /user/${USER}/${OUTPUT}_MRV1
 
 
 submit_mrv2: data ${PYINPUTFORMAT_JAR}
 	${SUBMIT_CMD} ${SUBMIT_ARGS} --input-format ${INPUT_FORMAT_MRV2} --mrv2\
-		            ${PROGNAME} ${INPUT} ${OUTPUT}_MRV2
+		            ${INPUT} ${OUTPUT}_MRV2
 	python check_results.py ${DATA} /user/${USER}/${OUTPUT}_MRV2
 
 

--- a/examples/input_format/Makefile
+++ b/examples/input_format/Makefile
@@ -31,7 +31,7 @@ SUBMIT_CMD=pydoop submit
 HDFS=$(if $(call pathsearch,hdfs),$(call pathsearch,hdfs) dfs ,\
        $(if $(call pathsearch,hadoop),$(call pathsearch,hadoop) fs ,\
 	       HDFS_IS_MISSING))
-HDFS_RMR=$(if $(call pathsearch,hdfs),$(call pathsearch,hdfs) dfs -rm -r,\
+HDFS_RMR=$(if $(call pathsearch,hdfs),$(call pathsearch,hdfs) dfs -rmr,\
 	       $(if $(call pathsearch,hadoop),$(call pathsearch,hadoop) fs -rmr,\
 	       HDFS_IS_MISSING))
 HDFS_PUT=${HDFS} -put
@@ -66,7 +66,6 @@ ${PYINPUTFORMAT_JAR}: $(CLASSES)
 
 data:
 	-${HDFS_MKDIR}  /user
-	-${HDFS_MKDIR} /user/${USER}
 	-${HDFS_MKDIR} /user/${USER}
 	-${HDFS_RMR} /user/${USER}/${INPUT}
 	-${HDFS_RMR} /user/${USER}/${OUTPUT}_*

--- a/examples/parquet/py/run_pavro.sh
+++ b/examples/parquet/py/run_pavro.sh
@@ -43,9 +43,8 @@ ${SUBMIT_CMD} --python-egg ${MZIP} \
               -D parquet.avro.projection="${USER_SCHEMA}" \
               -D avro.schema="${USER_SCHEMA}" \
               --libjars ${PARQUET_JAR} \
-              --module ${MODULE} \
               --log-level ${LOGLEVEL} ${MRV} --job-name ${JOBNAME} \
-              ${PROGNAME} ${INPUT} ${OUTPUT} 
+              ${MODULE} ${INPUT} ${OUTPUT}
 
 # ----- part 4 -----
 rm -rf ${OUTPUT}

--- a/examples/pydoop_script/run_base_histogram
+++ b/examples/pydoop_script/run_base_histogram
@@ -39,9 +39,9 @@ else
 	exit 1
 fi
 
-${hdfs} -rm -r /user/${USER}/${INPUT}
+${hdfs} -rmr /user/${USER}/${INPUT}
 ${hdfs} -mkdir /user/${USER}/${INPUT}
-${hdfs} -rm -r /user/${USER}/${OUTPUT}
+${hdfs} -rmr /user/${USER}/${OUTPUT}
 ${hdfs} -put ${DATA} ${INPUT}
 
 ${SCRIPT_CMD} ${SCRIPT} ${INPUT} ${OUTPUT}

--- a/examples/pydoop_script/run_caseswitch
+++ b/examples/pydoop_script/run_caseswitch
@@ -40,9 +40,9 @@ else
 	exit 1
 fi
 
-${hdfs} -rm -r /user/${USER}/${INPUT}
+${hdfs} -rmr /user/${USER}/${INPUT}
 ${hdfs} -mkdir /user/${USER}/${INPUT}
-${hdfs} -rm -r /user/${USER}/${OUTPUT}
+${hdfs} -rmr /user/${USER}/${OUTPUT}
 ${hdfs} -put ${DATA} ${INPUT}
 
 ${SCRIPT_CMD} --num-reducers 0 -t '' \

--- a/examples/pydoop_script/run_grep
+++ b/examples/pydoop_script/run_grep
@@ -40,9 +40,9 @@ else
 	exit 1
 fi
 
-${hdfs} -rm -r /user/${USER}/${INPUT}
+${hdfs} -rmr /user/${USER}/${INPUT}
 ${hdfs} -mkdir /user/${USER}/${INPUT}
-${hdfs} -rm -r /user/${USER}/${OUTPUT}
+${hdfs} -rmr /user/${USER}/${OUTPUT}
 ${hdfs} -put ${DATA} ${INPUT}
 
 ${SCRIPT_CMD} --num-reducers 0 -t '' \

--- a/examples/pydoop_script/run_lowercase
+++ b/examples/pydoop_script/run_lowercase
@@ -40,9 +40,9 @@ else
 	exit 1
 fi
 
-${hdfs} -rm -r /user/${USER}/${INPUT}
+${hdfs} -rmr /user/${USER}/${INPUT}
 ${hdfs} -mkdir /user/${USER}/${INPUT}
-${hdfs} -rm -r /user/${USER}/${OUTPUT}
+${hdfs} -rmr /user/${USER}/${OUTPUT}
 ${hdfs} -put ${DATA} ${INPUT}
 
 ${SCRIPT_CMD} --num-reducers 0 -t '' -D mapred.map.tasks=4 ${SCRIPT} ${INPUT} ${OUTPUT}

--- a/examples/pydoop_script/run_transpose
+++ b/examples/pydoop_script/run_transpose
@@ -41,9 +41,9 @@ else
 	exit 1
 fi
 
-${hdfs} -rm -r /user/${USER}/${INPUT}
+${hdfs} -rmr /user/${USER}/${INPUT}
 ${hdfs} -mkdir /user/${USER}/${INPUT}
-${hdfs} -rm -r /user/${USER}/${OUTPUT}
+${hdfs} -rmr /user/${USER}/${OUTPUT}
 ${hdfs} -put ${DATA} ${INPUT}
 
 ${SCRIPT_CMD} --num-reducers 4 -D mapred.map.tasks=2 ${SCRIPT} ${INPUT} ${OUTPUT}

--- a/examples/pydoop_submit/run_wordcount_full
+++ b/examples/pydoop_submit/run_wordcount_full
@@ -6,7 +6,6 @@ MPY=${MODULE}.py
 DATA=../input/alice.txt
 RESULTS='results.txt'
 
-PROGNAME=${MODULE}-prog
 JOBNAME=${MODULE}-job
 
 LOGLEVEL=INFO
@@ -38,9 +37,9 @@ ${SUBMIT_CMD} --python-zip ${MZIP} --python-program ${PYTHONBIN}\
               -D hadoop.pipes.java.recordreader=false \
               -D hadoop.pipes.java.recordwriter=false \
 							-D pydoop.hdfs.user=${USER} \
-              --module ${MODULE} --entry-point main \
+              --entry-point main \
               --log-level ${LOGLEVEL} --job-name ${JOBNAME} \
-              ${PROGNAME} ${INPUT} ${OUTPUT} 
+              ${MODULE} ${INPUT} ${OUTPUT}
 
 ${hdfs} -cat ${OUTPUT}/part'*' > ${RESULTS}
 

--- a/examples/pydoop_submit/run_wordcount_full
+++ b/examples/pydoop_submit/run_wordcount_full
@@ -28,9 +28,9 @@ fi
 
 zip -j ${MZIP} ../wordcount/new_api/${MPY}
 
-${hdfs} -rm -r /user/${USER}/${INPUT}
+${hdfs} -rmr /user/${USER}/${INPUT}
 ${hdfs} -mkdir /user/${USER}/${INPUT}
-${hdfs} -rm -r /user/${USER}/${OUTPUT}
+${hdfs} -rmr /user/${USER}/${OUTPUT}
 ${hdfs} -put ${DATA} ${INPUT}
 
 ${SUBMIT_CMD} --python-zip ${MZIP} --python-program ${PYTHONBIN}\

--- a/examples/pydoop_submit/run_wordcount_full
+++ b/examples/pydoop_submit/run_wordcount_full
@@ -18,12 +18,12 @@ SUBMIT_CMD="pydoop submit"
 PYTHONBIN=${PYTHONBIN:-python}
 
 if type -P hdfs >/dev/null; then
-	hdfs="$(type -P hdfs) dfs "
+  hdfs="$(type -P hdfs) dfs "
 elif type -P hadoop >/dev/null; then
-	hdfs="$(type -P hadoop) fs "
+  hdfs="$(type -P hadoop) fs "
 else
-	echo "Cannot find hdfs or hadoop executables" >&2
-	exit 1
+  echo "Cannot find hdfs or hadoop executables" >&2
+  exit 1
 fi
 
 zip -j ${MZIP} ../wordcount/new_api/${MPY}
@@ -36,7 +36,7 @@ ${hdfs} -put ${DATA} ${INPUT}
 ${SUBMIT_CMD} --python-zip ${MZIP} --python-program ${PYTHONBIN}\
               -D hadoop.pipes.java.recordreader=false \
               -D hadoop.pipes.java.recordwriter=false \
-							-D pydoop.hdfs.user=${USER} \
+              -D pydoop.hdfs.user=${USER} \
               --entry-point main \
               --log-level ${LOGLEVEL} --job-name ${JOBNAME} \
               ${MODULE} ${INPUT} ${OUTPUT}

--- a/examples/pydoop_submit/run_wordcount_minimal
+++ b/examples/pydoop_submit/run_wordcount_minimal
@@ -6,7 +6,6 @@ MPY=${MODULE}.py
 DATA=../input/alice.txt
 RESULTS=results.txt
 
-PROGNAME=${MODULE}-prog
 JOBNAME=${MODULE}-job
 
 LOGLEVEL=INFO
@@ -39,9 +38,9 @@ ${SUBMIT_CMD} --python-zip ${MZIP} --python-program ${PYTHONBIN}\
               -D mapreduce.pipes.isjavarecordreader=true \
               -D mapreduce.pipes.isjavarecordwriter=true \
 							-D pydoop.hdfs.user=${USER} \
-              --module ${MODULE} --entry-point main \
+               --entry-point main \
               --log-level ${LOGLEVEL} --job-name ${JOBNAME} \
-              ${PROGNAME} ${INPUT} ${OUTPUT} 
+              ${MODULE} ${INPUT} ${OUTPUT} 
 
 ${hdfs} -cat ${OUTPUT}/part'*' > ${RESULTS}
 

--- a/examples/pydoop_submit/run_wordcount_minimal
+++ b/examples/pydoop_submit/run_wordcount_minimal
@@ -29,9 +29,9 @@ fi
 
 zip -j ${MZIP} ../wordcount/new_api/${MPY}
 
-${hdfs} -rm -r /user/${USER}/${INPUT}
+${hdfs} -rmr /user/${USER}/${INPUT}
 ${hdfs} -mkdir /user/${USER}/${INPUT}
-${hdfs} -rm -r /user/${USER}/${OUTPUT}
+${hdfs} -rmr /user/${USER}/${OUTPUT}
 ${hdfs} -put ${DATA} ${INPUT}
 
 ${SUBMIT_CMD} --python-zip ${MZIP} --python-program ${PYTHONBIN}\

--- a/examples/pydoop_submit/run_wordcount_minimal
+++ b/examples/pydoop_submit/run_wordcount_minimal
@@ -19,12 +19,12 @@ PYTHONBIN=${PYTHONBIN:-python}
 
 
 if type -P hdfs >/dev/null; then
-	hdfs="$(type -P hdfs) dfs "
+  hdfs="$(type -P hdfs) dfs "
 elif type -P hadoop >/dev/null; then
-	hdfs="$(type -P hadoop) fs "
+  hdfs="$(type -P hadoop) fs "
 else
-	echo "Cannot find hdfs or hadoop executables" >&2
-	exit 1
+  echo "Cannot find hdfs or hadoop executables" >&2
+  exit 1
 fi
 
 zip -j ${MZIP} ../wordcount/new_api/${MPY}
@@ -37,10 +37,10 @@ ${hdfs} -put ${DATA} ${INPUT}
 ${SUBMIT_CMD} --python-zip ${MZIP} --python-program ${PYTHONBIN}\
               -D mapreduce.pipes.isjavarecordreader=true \
               -D mapreduce.pipes.isjavarecordwriter=true \
-							-D pydoop.hdfs.user=${USER} \
+              -D pydoop.hdfs.user=${USER} \
                --entry-point main \
               --log-level ${LOGLEVEL} --job-name ${JOBNAME} \
-              ${MODULE} ${INPUT} ${OUTPUT} 
+              ${MODULE} ${INPUT} ${OUTPUT}
 
 ${hdfs} -cat ${OUTPUT}/part'*' > ${RESULTS}
 

--- a/examples/self_contained/Makefile
+++ b/examples/self_contained/Makefile
@@ -54,10 +54,10 @@ setup_io:
 submit: vowelcount.zip pydoop.tgz setup_io
 	${SUBMIT_CMD} --python-zip vowelcount.zip \
                 --upload-archive-to-cache pydoop.tgz\
-                --module vowelcount.mr.main --entry-point main\
                 --log-level ${LOGLEVEL} --job-name ${JOBNAME}\
                 --no-override-home --no-override-env\
-	              ${PROGNAME} ${INPUT} ${OUTPUT}
+                vowelcount.mr.main --entry-point main \
+	              ${INPUT} ${OUTPUT}
 
 submit2: vowelcount.tgz pydoop.tgz setup_io
 	${SUBMIT_CMD} --upload-archive-to-cache vowelcount.tgz\

--- a/pydoop/app/submit.py
+++ b/pydoop/app/submit.py
@@ -79,6 +79,7 @@ class PydoopSubmitter(object):
         self.remote_exe = None
         self.pipes_code = None
         self.files_to_upload = []
+        self.unknown_args = None
 
     def __set_files_to_cache_helper(self, prop, upload_and_cache, cache):
         cfiles = self.properties[prop] if self.properties[prop] else []
@@ -212,7 +213,7 @@ class PydoopSubmitter(object):
         if self.args.log_level == "DEBUG":
             lines.append("echo ${PYTHONPATH} 1>&2")
             lines.append("echo ${LD_LIBRARY_PATH} 1>&2")
-            lines.append("echo ${HOME} 1>&2")             
+            lines.append("echo ${HOME} 1>&2")
         lines.append('exec "%s" -u "$0" "$@"' % executable)
         lines.append('":"""')
         if self.args.log_level == "DEBUG":

--- a/pydoop/app/submit.py
+++ b/pydoop/app/submit.py
@@ -24,6 +24,7 @@ import os
 import sys
 import argparse
 import logging
+import uuid
 logging.basicConfig(level=logging.INFO)
 
 import pydoop
@@ -121,7 +122,7 @@ class PydoopSubmitter(object):
         self.remote_wd = hdfs.path.join(
             parent, utils.make_random_str(prefix="pydoop_submit_")
         )
-        self.remote_exe = args.program
+        self.remote_exe = hdfs.path.join(self.remote_wd, str(uuid.uuid4()))
         self.properties[JOB_NAME] = args.job_name or 'pydoop'
         self.properties[IS_JAVA_RR] = (
             'false' if args.do_not_use_java_record_reader else 'true'
@@ -258,10 +259,9 @@ class PydoopSubmitter(object):
             hdfs.mkdir(self.remote_wd)
             hdfs.chmod(self.remote_wd, "a+rx")
             self.logger.debug("created and chmod-ed: %s", self.remote_wd)
-            if self.args.module:
-                pipes_code = self.__generate_pipes_code()
-                hdfs.dump(pipes_code, self.remote_exe)
-                self.logger.debug("dumped pipes_code to: %s", self.remote_exe)
+            pipes_code = self.__generate_pipes_code()
+            hdfs.dump(pipes_code, self.remote_exe)
+            self.logger.debug("dumped pipes_code to: %s", self.remote_exe)
             hdfs.chmod(self.remote_exe, "a+rx")
             self.__warn_user_if_wd_maybe_unreadable(self.remote_wd)
             for (l, h, _) in self.files_to_upload:
@@ -402,7 +402,8 @@ def add_parser_common_arguments(parser):
 
 def add_parser_arguments(parser):
     parser.add_argument(
-        'program', metavar='PROGRAM', help='the python mapreduce program',
+        'module', metavar='MODULE', type=str,
+        help=("The module containing the Python MapReduce program")
     )
     parser.add_argument(
         'input', metavar='INPUT', help='input path to the maps',
@@ -461,13 +462,6 @@ def add_parser_arguments(parser):
         action="append",
         help="Add this HDFS archive file to the distributed cache" +
              "as an archive."
-    )
-    parser.add_argument(
-        '--module', metavar='MODULE', type=str,
-        help=("Create a launcher that will execute MODULE code "
-              "in the appropriate launch environment."
-              "The resulting pydoop program will be written "
-              "at the HDFS path defined by PROGRAM")
     )
     parser.add_argument(
         '--entry-point', metavar='ENTRY_POINT', type=str,

--- a/pydoop/app/submit.py
+++ b/pydoop/app/submit.py
@@ -113,10 +113,12 @@ class PydoopSubmitter(object):
                                          args.upload_archive_to_cache,
                                          args.cache_archive)
 
-    def set_args(self, args, unknown_args=[]):
+    def set_args(self, args, unknown_args=None):
         """
         Configure job, based on the arguments provided.
         """
+        if unknown_args is None:
+            unknown_args = []
         self.logger.setLevel(getattr(logging, args.log_level))
 
         parent = hdfs.path.dirname(hdfs.path.abspath(args.output.rstrip("/")))
@@ -336,7 +338,9 @@ class PydoopSubmitter(object):
                          (submitter_class, args, properties, classpath))
 
 
-def run(args, unknown_args=[]):
+def run(args, unknown_args=None):
+    if unknown_args is None:
+        unknown_args = []
     script = PydoopSubmitter()
     script.set_args(args, unknown_args)
     script.run()

--- a/test/app/test_submit.py
+++ b/test/app/test_submit.py
@@ -75,7 +75,7 @@ class TestAppSubmit(unittest.TestCase):
                    ("--output-format", 'mapreduce.lib.input.TextOutputFormat'),
                    ("--num-reducers", 10),
                    ("--python-zip", 'allmymodules.zip'),
-                   ("--module", 'mymod1.mod2.mod3'))
+                   )
         try:
             with open(conf_file, 'w') as cf:
                 d = ''.join(['{}\n{}\n'.format(k, v)
@@ -84,12 +84,12 @@ class TestAppSubmit(unittest.TestCase):
                 cf.write(d)
             parser = app.make_parser()
             parser.format_help = nop
-            program = 'program'
+            module = 'mymod1.mod2.mod3'
             ainput = 'input'
             aoutput = 'output'
-            argv = ['submit', program, ainput, aoutput, '@' + conf_file]
+            argv = ['submit', module, ainput, aoutput, '@' + conf_file]
             [args, unknown] = parser.parse_known_args(argv)
-            self.assertEqual(args.program, program)
+            self.assertEqual(args.module, module)
             self.assertEqual(args.input, ainput)
             self.assertEqual(args.output, aoutput)
             self.assertEqual(len(unknown), 0)


### PR DESCRIPTION
Change pydoop submit's command line interface removing the "program" argument for the remote script file that's created and passed to hadoop pipes.  Instead, we use a random name and the temporary script is deleted after the job completes.