### PR TITLE
Change submit args.2

### DIFF
--- a/examples/avro/py/run_py_only_map_reduce.sh
+++ b/examples/avro/py/run_py_only_map_reduce.sh
@@ -30,7 +30,6 @@ ${SUBMIT_CMD} --python-egg ${MZIP} --upload-to-cache ${AVRO_STATS_AVSC} \
                                    --upload-to-cache ${AVRO_USER_AVSC} \
               -D mapreduce.pipes.isjavarecordreader=false \
               -D mapreduce.pipes.isjavarecordwriter=false \
-              --module ${MODULE} \
               --log-level ${LOGLEVEL} ${MRV} --job-name ${JOBNAME} \
-              ${PROGNAME} ${INPUT} ${OUTPUT} 
+              ${MODULE} ${INPUT} ${OUTPUT}
 

--- a/examples/input_format/Makefile
+++ b/examples/input_format/Makefile
@@ -20,11 +20,10 @@ PYINPUTFORMAT_JAR=pydoop-input-formats.jar
 INPUT_FORMAT_MRV1=it.crs4.pydoop.mapred.TextInputFormat
 INPUT_FORMAT_MRV2=it.crs4.pydoop.mapreduce.TextInputFormat
 LOGLEVEL=INFO
-PROGNAME=input_format_test
 JOBNAME=input_format_test_job
 DATA := ../input
-INPUT=${PROGNAME}_input
-OUTPUT=${PROGNAME}_output
+INPUT=${JOBNAME}_input
+OUTPUT=${JOBNAME}_output
 
 pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
 SUBMIT_CMD=pydoop submit
@@ -46,8 +45,8 @@ SRC = $(wildcard it/crs4/pydoop/mapred*/TextInputFormat.java)
 CLASSES = $(subst .java,.class,$(SRC))
 
 SUBMIT_ARGS = --upload-file-to-cache wordcount_rr.py \
+wordcount_rr \
 --libjars ${PYINPUTFORMAT_JAR}\
---module wordcount_rr\
 --do-not-use-java-record-reader\
 -D pydoop.input.issplitable=true\
 --log-level ${LOGLEVEL} --job-name ${JOBNAME}
@@ -76,13 +75,13 @@ data:
 
 submit_mrv1: data ${PYINPUTFORMAT_JAR}
 	${SUBMIT_CMD} ${SUBMIT_ARGS} --input-format ${INPUT_FORMAT_MRV1}\
-		            ${PROGNAME} ${INPUT} ${OUTPUT}_MRV1
+		            ${INPUT} ${OUTPUT}_MRV1
 	python check_results.py ${DATA} /user/${USER}/${OUTPUT}_MRV1
 
 
 submit_mrv2: data ${PYINPUTFORMAT_JAR}
 	${SUBMIT_CMD} ${SUBMIT_ARGS} --input-format ${INPUT_FORMAT_MRV2} --mrv2\
-		            ${PROGNAME} ${INPUT} ${OUTPUT}_MRV2
+		            ${INPUT} ${OUTPUT}_MRV2
 	python check_results.py ${DATA} /user/${USER}/${OUTPUT}_MRV2
 
 

--- a/examples/input_format/Makefile
+++ b/examples/input_format/Makefile
@@ -31,7 +31,7 @@ SUBMIT_CMD=pydoop submit
 HDFS=$(if $(call pathsearch,hdfs),$(call pathsearch,hdfs) dfs ,\
        $(if $(call pathsearch,hadoop),$(call pathsearch,hadoop) fs ,\
 	       HDFS_IS_MISSING))
-HDFS_RMR=$(if $(call pathsearch,hdfs),$(call pathsearch,hdfs) dfs -rm -r,\
+HDFS_RMR=$(if $(call pathsearch,hdfs),$(call pathsearch,hdfs) dfs -rmr,\
 	       $(if $(call pathsearch,hadoop),$(call pathsearch,hadoop) fs -rmr,\
 	       HDFS_IS_MISSING))
 HDFS_PUT=${HDFS} -put
@@ -66,7 +66,6 @@ ${PYINPUTFORMAT_JAR}: $(CLASSES)
 
 data:
 	-${HDFS_MKDIR}  /user
-	-${HDFS_MKDIR} /user/${USER}
 	-${HDFS_MKDIR} /user/${USER}
 	-${HDFS_RMR} /user/${USER}/${INPUT}
 	-${HDFS_RMR} /user/${USER}/${OUTPUT}_*

--- a/examples/parquet/py/run_pavro.sh
+++ b/examples/parquet/py/run_pavro.sh
@@ -43,9 +43,8 @@ ${SUBMIT_CMD} --python-egg ${MZIP} \
               -D parquet.avro.projection="${USER_SCHEMA}" \
               -D avro.schema="${USER_SCHEMA}" \
               --libjars ${PARQUET_JAR} \
-              --module ${MODULE} \
               --log-level ${LOGLEVEL} ${MRV} --job-name ${JOBNAME} \
-              ${PROGNAME} ${INPUT} ${OUTPUT} 
+              ${MODULE} ${INPUT} ${OUTPUT}
 
 # ----- part 4 -----
 rm -rf ${OUTPUT}

--- a/examples/pydoop_script/run_base_histogram
+++ b/examples/pydoop_script/run_base_histogram
@@ -39,9 +39,9 @@ else
 	exit 1
 fi
 
-${hdfs} -rm -r /user/${USER}/${INPUT}
+${hdfs} -rmr /user/${USER}/${INPUT}
 ${hdfs} -mkdir /user/${USER}/${INPUT}
-${hdfs} -rm -r /user/${USER}/${OUTPUT}
+${hdfs} -rmr /user/${USER}/${OUTPUT}
 ${hdfs} -put ${DATA} ${INPUT}
 
 ${SCRIPT_CMD} ${SCRIPT} ${INPUT} ${OUTPUT}

--- a/examples/pydoop_script/run_caseswitch
+++ b/examples/pydoop_script/run_caseswitch
@@ -40,9 +40,9 @@ else
 	exit 1
 fi
 
-${hdfs} -rm -r /user/${USER}/${INPUT}
+${hdfs} -rmr /user/${USER}/${INPUT}
 ${hdfs} -mkdir /user/${USER}/${INPUT}
-${hdfs} -rm -r /user/${USER}/${OUTPUT}
+${hdfs} -rmr /user/${USER}/${OUTPUT}
 ${hdfs} -put ${DATA} ${INPUT}
 
 ${SCRIPT_CMD} --num-reducers 0 -t '' \

--- a/examples/pydoop_script/run_grep
+++ b/examples/pydoop_script/run_grep
@@ -40,9 +40,9 @@ else
 	exit 1
 fi
 
-${hdfs} -rm -r /user/${USER}/${INPUT}
+${hdfs} -rmr /user/${USER}/${INPUT}
 ${hdfs} -mkdir /user/${USER}/${INPUT}
-${hdfs} -rm -r /user/${USER}/${OUTPUT}
+${hdfs} -rmr /user/${USER}/${OUTPUT}
 ${hdfs} -put ${DATA} ${INPUT}
 
 ${SCRIPT_CMD} --num-reducers 0 -t '' \

--- a/examples/pydoop_script/run_lowercase
+++ b/examples/pydoop_script/run_lowercase
@@ -40,9 +40,9 @@ else
 	exit 1
 fi
 
-${hdfs} -rm -r /user/${USER}/${INPUT}
+${hdfs} -rmr /user/${USER}/${INPUT}
 ${hdfs} -mkdir /user/${USER}/${INPUT}
-${hdfs} -rm -r /user/${USER}/${OUTPUT}
+${hdfs} -rmr /user/${USER}/${OUTPUT}
 ${hdfs} -put ${DATA} ${INPUT}
 
 ${SCRIPT_CMD} --num-reducers 0 -t '' -D mapred.map.tasks=4 ${SCRIPT} ${INPUT} ${OUTPUT}

--- a/examples/pydoop_script/run_transpose
+++ b/examples/pydoop_script/run_transpose
@@ -41,9 +41,9 @@ else
 	exit 1
 fi
 
-${hdfs} -rm -r /user/${USER}/${INPUT}
+${hdfs} -rmr /user/${USER}/${INPUT}
 ${hdfs} -mkdir /user/${USER}/${INPUT}
-${hdfs} -rm -r /user/${USER}/${OUTPUT}
+${hdfs} -rmr /user/${USER}/${OUTPUT}
 ${hdfs} -put ${DATA} ${INPUT}
 
 ${SCRIPT_CMD} --num-reducers 4 -D mapred.map.tasks=2 ${SCRIPT} ${INPUT} ${OUTPUT}

--- a/examples/pydoop_submit/run_wordcount_full
+++ b/examples/pydoop_submit/run_wordcount_full
@@ -6,7 +6,6 @@ MPY=${MODULE}.py
 DATA=../input/alice.txt
 RESULTS='results.txt'
 
-PROGNAME=${MODULE}-prog
 JOBNAME=${MODULE}-job
 
 LOGLEVEL=INFO
@@ -38,9 +37,9 @@ ${SUBMIT_CMD} --python-zip ${MZIP} --python-program ${PYTHONBIN}\
               -D hadoop.pipes.java.recordreader=false \
               -D hadoop.pipes.java.recordwriter=false \
 							-D pydoop.hdfs.user=${USER} \
-              --module ${MODULE} --entry-point main \
+              --entry-point main \
               --log-level ${LOGLEVEL} --job-name ${JOBNAME} \
-              ${PROGNAME} ${INPUT} ${OUTPUT} 
+              ${MODULE} ${INPUT} ${OUTPUT}
 
 ${hdfs} -cat ${OUTPUT}/part'*' > ${RESULTS}
 

--- a/examples/pydoop_submit/run_wordcount_full
+++ b/examples/pydoop_submit/run_wordcount_full
@@ -28,9 +28,9 @@ fi
 
 zip -j ${MZIP} ../wordcount/new_api/${MPY}
 
-${hdfs} -rm -r /user/${USER}/${INPUT}
+${hdfs} -rmr /user/${USER}/${INPUT}
 ${hdfs} -mkdir /user/${USER}/${INPUT}
-${hdfs} -rm -r /user/${USER}/${OUTPUT}
+${hdfs} -rmr /user/${USER}/${OUTPUT}
 ${hdfs} -put ${DATA} ${INPUT}
 
 ${SUBMIT_CMD} --python-zip ${MZIP} --python-program ${PYTHONBIN}\

--- a/examples/pydoop_submit/run_wordcount_full
+++ b/examples/pydoop_submit/run_wordcount_full
@@ -18,12 +18,12 @@ SUBMIT_CMD="pydoop submit"
 PYTHONBIN=${PYTHONBIN:-python}
 
 if type -P hdfs >/dev/null; then
-	hdfs="$(type -P hdfs) dfs "
+  hdfs="$(type -P hdfs) dfs "
 elif type -P hadoop >/dev/null; then
-	hdfs="$(type -P hadoop) fs "
+  hdfs="$(type -P hadoop) fs "
 else
-	echo "Cannot find hdfs or hadoop executables" >&2
-	exit 1
+  echo "Cannot find hdfs or hadoop executables" >&2
+  exit 1
 fi
 
 zip -j ${MZIP} ../wordcount/new_api/${MPY}
@@ -36,7 +36,7 @@ ${hdfs} -put ${DATA} ${INPUT}
 ${SUBMIT_CMD} --python-zip ${MZIP} --python-program ${PYTHONBIN}\
               -D hadoop.pipes.java.recordreader=false \
               -D hadoop.pipes.java.recordwriter=false \
-							-D pydoop.hdfs.user=${USER} \
+              -D pydoop.hdfs.user=${USER} \
               --entry-point main \
               --log-level ${LOGLEVEL} --job-name ${JOBNAME} \
               ${MODULE} ${INPUT} ${OUTPUT}

--- a/examples/pydoop_submit/run_wordcount_minimal
+++ b/examples/pydoop_submit/run_wordcount_minimal
@@ -6,7 +6,6 @@ MPY=${MODULE}.py
 DATA=../input/alice.txt
 RESULTS=results.txt
 
-PROGNAME=${MODULE}-prog
 JOBNAME=${MODULE}-job
 
 LOGLEVEL=INFO
@@ -39,9 +38,9 @@ ${SUBMIT_CMD} --python-zip ${MZIP} --python-program ${PYTHONBIN}\
               -D mapreduce.pipes.isjavarecordreader=true \
               -D mapreduce.pipes.isjavarecordwriter=true \
 							-D pydoop.hdfs.user=${USER} \
-              --module ${MODULE} --entry-point main \
+               --entry-point main \
               --log-level ${LOGLEVEL} --job-name ${JOBNAME} \
-              ${PROGNAME} ${INPUT} ${OUTPUT} 
+              ${MODULE} ${INPUT} ${OUTPUT} 
 
 ${hdfs} -cat ${OUTPUT}/part'*' > ${RESULTS}
 

--- a/examples/pydoop_submit/run_wordcount_minimal
+++ b/examples/pydoop_submit/run_wordcount_minimal
@@ -29,9 +29,9 @@ fi
 
 zip -j ${MZIP} ../wordcount/new_api/${MPY}
 
-${hdfs} -rm -r /user/${USER}/${INPUT}
+${hdfs} -rmr /user/${USER}/${INPUT}
 ${hdfs} -mkdir /user/${USER}/${INPUT}
-${hdfs} -rm -r /user/${USER}/${OUTPUT}
+${hdfs} -rmr /user/${USER}/${OUTPUT}
 ${hdfs} -put ${DATA} ${INPUT}
 
 ${SUBMIT_CMD} --python-zip ${MZIP} --python-program ${PYTHONBIN}\

--- a/examples/pydoop_submit/run_wordcount_minimal
+++ b/examples/pydoop_submit/run_wordcount_minimal
@@ -19,12 +19,12 @@ PYTHONBIN=${PYTHONBIN:-python}
 
 
 if type -P hdfs >/dev/null; then
-	hdfs="$(type -P hdfs) dfs "
+  hdfs="$(type -P hdfs) dfs "
 elif type -P hadoop >/dev/null; then
-	hdfs="$(type -P hadoop) fs "
+  hdfs="$(type -P hadoop) fs "
 else
-	echo "Cannot find hdfs or hadoop executables" >&2
-	exit 1
+  echo "Cannot find hdfs or hadoop executables" >&2
+  exit 1
 fi
 
 zip -j ${MZIP} ../wordcount/new_api/${MPY}
@@ -37,10 +37,10 @@ ${hdfs} -put ${DATA} ${INPUT}
 ${SUBMIT_CMD} --python-zip ${MZIP} --python-program ${PYTHONBIN}\
               -D mapreduce.pipes.isjavarecordreader=true \
               -D mapreduce.pipes.isjavarecordwriter=true \
-							-D pydoop.hdfs.user=${USER} \
+              -D pydoop.hdfs.user=${USER} \
                --entry-point main \
               --log-level ${LOGLEVEL} --job-name ${JOBNAME} \
-              ${MODULE} ${INPUT} ${OUTPUT} 
+              ${MODULE} ${INPUT} ${OUTPUT}
 
 ${hdfs} -cat ${OUTPUT}/part'*' > ${RESULTS}
 

--- a/examples/self_contained/Makefile
+++ b/examples/self_contained/Makefile
@@ -54,10 +54,10 @@ setup_io:
 submit: vowelcount.zip pydoop.tgz setup_io
 	${SUBMIT_CMD} --python-zip vowelcount.zip \
                 --upload-archive-to-cache pydoop.tgz\
-                --module vowelcount.mr.main --entry-point main\
                 --log-level ${LOGLEVEL} --job-name ${JOBNAME}\
                 --no-override-home --no-override-env\
-	              ${PROGNAME} ${INPUT} ${OUTPUT}
+                vowelcount.mr.main --entry-point main \
+	              ${INPUT} ${OUTPUT}
 
 submit2: vowelcount.tgz pydoop.tgz setup_io
 	${SUBMIT_CMD} --upload-archive-to-cache vowelcount.tgz\

--- a/pydoop/app/script.py
+++ b/pydoop/app/script.py
@@ -120,7 +120,9 @@ class PydoopScript(object):
         os.unlink(self.zip_filename)
 
 
-def run(args, unknown_args=[]):
+def run(args, unknown_args=None):
+    if unknown_args is None:
+        unknown_args = []
     scripter = PydoopScript(args, unknown_args)
     scripter.run()
     scripter.clean()

--- a/pydoop/app/submit.py
+++ b/pydoop/app/submit.py
@@ -113,10 +113,12 @@ class PydoopSubmitter(object):
                                          args.upload_archive_to_cache,
                                          args.cache_archive)
 
-    def set_args(self, args, unknown_args=[]):
+    def set_args(self, args, unknown_args=None):
         """
         Configure job, based on the arguments provided.
         """
+        if unknown_args is None:
+            unknown_args = []
         self.logger.setLevel(getattr(logging, args.log_level))
 
         parent = hdfs.path.dirname(hdfs.path.abspath(args.output.rstrip("/")))
@@ -337,7 +339,9 @@ class PydoopSubmitter(object):
                          (submitter_class, args, properties, classpath))
 
 
-def run(args, unknown_args=[]):
+def run(args, unknown_args=None):
+    if unknown_args is None:
+        unknown_args = []
     script = PydoopSubmitter()
     script.set_args(args, unknown_args)
     script.run()

--- a/pydoop/app/submit.py
+++ b/pydoop/app/submit.py
@@ -79,6 +79,7 @@ class PydoopSubmitter(object):
         self.remote_exe = None
         self.pipes_code = None
         self.files_to_upload = []
+        self.unknown_args = None
 
     def __set_files_to_cache_helper(self, prop, upload_and_cache, cache):
         cfiles = self.properties[prop] if self.properties[prop] else []

--- a/test/app/test_submit.py
+++ b/test/app/test_submit.py
@@ -75,7 +75,7 @@ class TestAppSubmit(unittest.TestCase):
                    ("--output-format", 'mapreduce.lib.input.TextOutputFormat'),
                    ("--num-reducers", 10),
                    ("--python-zip", 'allmymodules.zip'),
-                   ("--module", 'mymod1.mod2.mod3'))
+                   )
         try:
             with open(conf_file, 'w') as cf:
                 d = ''.join(['{}\n{}\n'.format(k, v)
@@ -84,12 +84,12 @@ class TestAppSubmit(unittest.TestCase):
                 cf.write(d)
             parser = app.make_parser()
             parser.format_help = nop
-            program = 'program'
+            module = 'mymod1.mod2.mod3'
             ainput = 'input'
             aoutput = 'output'
-            argv = ['submit', program, ainput, aoutput, '@' + conf_file]
+            argv = ['submit', module, ainput, aoutput, '@' + conf_file]
             [args, unknown] = parser.parse_known_args(argv)
-            self.assertEqual(args.program, program)
+            self.assertEqual(args.module, module)
             self.assertEqual(args.input, ainput)
             self.assertEqual(args.output, aoutput)
             self.assertEqual(len(unknown), 0)


### PR DESCRIPTION
Remove "PROGRAM" argument from the `pydoop submit` command.  Instead, `hadoop pipes` is given a temporary file, with a unique randomly generated name, that is deleted as soon as the job is finished.