### PR TITLE
Use only the first 3 items in the version tuple when selecting Java source

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,7 @@ def build_hdfscore_native_impl():
         inc_dirs = (jvm.get_include_dirs() +
                     ['src/libhdfsV2', 'src/libhdfsV2/os/posix'])
     else:
-        src_dir = 'src/libhdfs/%d.%d.%d' % hadoop_t
+        src_dir = 'src/libhdfs/%d.%d.%d' % hadoop_t[0:3]
         hdfs_ext_sources += glob.glob(os.path.join(src_dir, '*.c'))
         inc_dirs = jvm.get_include_dirs() + [src_dir]
         libhdfs_macros = [("HADOOP_LIBHDFS_V1", 1)]


### PR DESCRIPTION
Some Hadoop builds have extra "appendages" in their version names (e.g.,
"SNAPSHOT").  To select the best-fit version of libhdfs code we need to
ignore those version appendages when assembling the source path.