### PR TITLE
Fix OS X warning 

### DIFF
--- a/src/libhdfsV2/hdfs.c
+++ b/src/libhdfsV2/hdfs.c
@@ -2742,7 +2742,7 @@ tOffset hdfsGetDefaultBlockSizeAtPath(hdfsFS fs, const char *path)
     jthrowable jthr;
     jobject jFS = (jobject)fs;
     jobject jPath;
-    tOffset blockSize;
+    jlong blockSize; // jlong & tOffset are defined as aliases of int64_t
     JNIEnv* env = getJNIEnv();
 
     if (env == NULL) {
@@ -2764,7 +2764,7 @@ tOffset hdfsGetDefaultBlockSizeAtPath(hdfsFS fs, const char *path)
             "FileSystem#getDefaultBlockSize", path);
         return -1;
     }
-    return blockSize;
+    return (tOffset) blockSize;
 }
 
 


### PR DESCRIPTION
Fixes the OS X compiler warning below (also mentioned in #19):
```
src/hadoop-2.4.0.patched/libhdfs/hdfs.c:2331:49: warning: incompatible pointer types passing 'tOffset *' (aka 'long long *') to parameter of type 'jlong *' (aka 'long *')
      [-Wincompatible-pointer-types]
    jthr = getDefaultBlockSize(env, jFS, jPath, &blockSize);
                                                ^~~~~~~~~~
src/hadoop-2.4.0.patched/libhdfs/hdfs.c:787:61: note: passing argument to parameter 'out' here
                                      jobject jPath, jlong *out)
                                                            ^
1 warning generated.
```
Such a warning is because the OS X version JNI maps jlong to long.