### PR TITLE
Simplify cluster client node creation.

### DIFF
--- a/dev_tools/docker/client_side_tests/apache_2.6.0/initialize.sh
+++ b/dev_tools/docker/client_side_tests/apache_2.6.0/initialize.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 
-if [[ -z "${DOCKER_HOST_IP}" ]]
-then 
-	echo "No explicit DOCKER_HOST_IP in your env: localhost is assumed"
-	DOCKER_HOST_IP=localhost
-fi
-
-cl_container_id=$(docker ps | grep client | awk '{print $1}')
-rm_container_id=$(docker ps | grep resourcemanager | awk '{print $1}')
-
-(cat ${HOME}/.ssh/id_dsa.pub | docker exec -i ${cl_container_id} tee -a /root/.ssh/authorized_keys) > /dev/null
+port=$1
+client_id=$2
+rm_container_id=$3
+DOCKER_HOST_IP=${4:-localhost}
+#----------------------------------
+client_name=`docker exec ${client_id} hostname`
 
 #----- Upload hadoop to the client container
 hdp_ver=hadoop-2.6.0
@@ -21,13 +17,13 @@ then
 fi
 
 # copy the hadoop*.tar.gz
-scp -P2222 ${hdp_tgz} root@${DOCKER_HOST_IP}:/opt/
+scp -P${port} ${hdp_tgz} root@${DOCKER_HOST_IP}:/opt/
 
 # copy the installer script
-scp -P2222 local_client_setup.sh root@${DOCKER_HOST_IP}:.
+scp -P${port} local_client_setup.sh root@${DOCKER_HOST_IP}:.
 
 # exec and remove the installer script
-ssh -p2222 root@${DOCKER_HOST_IP} './local_client_setup.sh && rm local_client_setup.sh'
+ssh -p${port} root@${DOCKER_HOST_IP} './local_client_setup.sh && rm local_client_setup.sh'
 
 # copy the hadoop configuration from the resourcemanager container to the client container
 echo "Copying hadoop config from the resourcemanager container..."
@@ -35,6 +31,6 @@ for c in core-site.xml mapred-site.xml yarn-site.xml
 do
     from=/opt/hadoop/etc/hadoop/${c}
     to=/opt/hadoop/etc/hadoop/${c}
-    docker exec -it ${rm_container_id} scp ${from} client:${to}
+    docker exec -it ${rm_container_id} scp ${from} ${client_name}:${to}
 done
 

--- a/dev_tools/docker/client_side_tests/hdp_2.2.0.0/initialize.sh
+++ b/dev_tools/docker/client_side_tests/hdp_2.2.0.0/initialize.sh
@@ -1,21 +1,17 @@
 #!/bin/bash
 
+port=$1
+client_id=$2
+rm_container_id=$3
+DOCKER_HOST_IP=${4:-localhost}
+#----------------------------------
+client_name=`docker exec ${client_id} hostname`
 
-if [[ -z "${DOCKER_HOST_IP}" ]]
-then 
-	echo "No explicit DOCKER_HOST_IP in your env: localhost is assumed"
-	DOCKER_HOST_IP=localhost
-fi
-
-cl_container_id=$(docker ps | grep client | awk '{print $1}')
-rm_container_id=$(docker ps | grep resourcemanager | awk '{print $1}')
-
-(cat ${HOME}/.ssh/id_dsa.pub | docker exec -i ${cl_container_id} tee -a /root/.ssh/authorized_keys) > /dev/null
-
-scp -P2222 local_client_setup.sh root@${DOCKER_HOST_IP}:.
+#----------------------------------
+scp -P${port} local_client_setup.sh root@${DOCKER_HOST_IP}:.
 
 # exec and remove the installer script
-ssh -p2222 root@${DOCKER_HOST_IP} './local_client_setup.sh && rm local_client_setup.sh'
+ssh -p${port} root@${DOCKER_HOST_IP} './local_client_setup.sh && rm local_client_setup.sh'
 
 # copy the hadoop configuration from the resourcemanager container to the client container
 echo "Copying hadoop config from the resourcemanager container..."
@@ -23,6 +19,6 @@ for c in core-site.xml mapred-site.xml yarn-site.xml
 do
     from=/opt/hadoop/etc/hadoop/${c}
     to=/etc/hadoop/conf/${c}
-    docker exec -it ${rm_container_id} scp ${from} client:${to}
+    docker exec -it ${rm_container_id} scp ${from} ${client_name}:${to}
 done
 

--- a/dev_tools/docker/cluster.rst
+++ b/dev_tools/docker/cluster.rst
@@ -130,34 +130,25 @@ These are the basic steps.
 Change directory to ``client_side_tests``, choose a specific distribution, say
 ``apache_2.6.0`` and ``cd`` to that directory.
 
-Run the install script that configure the cluster client node. The script will
-install on the client the appropriate hadoop distribution, needed software, and
-a set of utility scripts. The specific command is::
+Run the following command::
 
- $ ./initialize.sh 
-   No explicit DOCKER_HOST_IP in your env: localhost is assumed
-   root@localhost's password: 
-   hadoop-2.6.0.tar.gz     100%  186MB  62.1MB/s  79.4MB/s   00:03    
-   local_client_setup.sh   100% 1724     1.7KB/s   1.7KB/s   00:00    
-   /opt ~
-   ~
-   Reading package lists...
-   Building dependency tree...
-   Reading state information...
-   The following extra packages will be installed:
-     unzip
-   The following NEW packages will be installed:
-     unzip zip
-   0 upgraded, 2 newly installed, 0 to remove and 1 not upgraded.
-   Need to get 531 kB of archives.
-   ....
-   Cleaning up...
-   Copying hadoop config from the resourcemanager container...
-   ...
+  $ ../../scripts/start_client.sh [<PORT>]
+
+The script will create a new docker container with a cluster client node that
+will respond to ssh connections on port ``PORT``, with 3333 as its default
+value.  The ``start_client.sh`` script will execute the bash script
+``initialize.sh``, see the provided client side tests for examples, to install
+on the client container the appropriate hadoop distribution, needed software,
+and a set of utility scripts.
+
+.. note::
+
+  You will probably have to answer twice 'yes' to ssh paranoia.
+
 
 Log in on the client, install pydoop and run the tests::
 
-  $ ssh -p 2222 root@localhost
+  $ ssh -p 3333 root@localhost
     Linux minas-morgul 3.18.7-gentoo #1 SMP Mon Feb 23 17:39:58 PST 2015 x86_64
     
     The programs included with the Debian GNU/Linux system are free software;

--- a/dev_tools/docker/scripts/start_client.sh
+++ b/dev_tools/docker/scripts/start_client.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+#-------------------------------------------
+#
+# Insert a new client in a running cluster
+#
+# Usage:
+#        $ cd client_side_tests/<client>
+#        $ ../../scripts/start_client.sh <PORT>
+#
+real_path=`readlink -f ${BASH_SOURCE[0]}`
+script_dir=`dirname ${real_path}`
+share_hosts_bin="python ${script_dir}/share_etc_hosts.py"
+
+client_dir=`basename $PWD`
+port=${1:-3333}
+
+if [[ -z "${DOCKER_HOST_IP}" ]]
+then 
+	echo "No explicit DOCKER_HOST_IP in your env: localhost is assumed"
+	DOCKER_HOST_IP=localhost
+fi
+
+# We assume that there is only one service with that name
+cluster_tag=$(docker ps | grep resourcemanager | \
+                     awk '{print $NF}'| sed -e 's/_.*$//')
+client_name=${cluster_tag}_client_${client_dir}
+docker run -d --name ${client_name} -p ${port}:22 crs4_pydoop/client:latest
+${share_hosts_bin} ${cluster_tag}
+
+rm_id=$(docker ps | grep resourcemanager | awk '{print $1}')
+client_id=$(docker ps | grep ${client_name} | awk '{print $1}')
+
+(cat ${HOME}/.ssh/id_dsa.pub | docker exec -i ${client_id} tee -a /root/.ssh/authorized_keys) > /dev/null
+
+if [ -x ./initialize.sh ]; then
+    ./initialize.sh ${port} ${client_id} ${rm_id}  ${DOCKER_HOST_IP}
+fi
+
+


### PR DESCRIPTION
We can now have multiple indipendent cluster-clients nodes, each one
with its own hadoop distribution. See cluster.rst for details.

[ci skip]