### PR TITLE
Fix AvroContext inheritance

### DIFF
--- a/pydoop/avrolib.py
+++ b/pydoop/avrolib.py
@@ -59,18 +59,17 @@ class AvroContext(pp.TaskContext):
     be explicitly requested when launching the application with pydoop
     submit (``--avro-input``, ``--avro-output``).
     """
-    @staticmethod
-    def deserializing(meth, datum_reader):
+    def deserializing(self, meth, datum_reader):
         """
         Decorate a key/value getter to make it auto-deserialize Avro
         records.
         """
-        def with_deserialization(self, *args, **kwargs):
-            ret = meth(self, *args, **kwargs)
+        def deserialize(*args, **kwargs):
+            ret = meth(*args, **kwargs)
             f = StringIO(ret)
             dec = BinaryDecoder(f)
             return datum_reader.read(dec)
-        return with_deserialization
+        return deserialize
 
     def __init__(self, up_link, private_encoding=True):
         super(AvroContext, self).__init__(up_link, private_encoding)
@@ -90,15 +89,15 @@ class AvroContext(pp.TaskContext):
                 reader = DatumReader(avro.schema.parse(
                     jc.get(AVRO_KEY_INPUT_SCHEMA)
                 ))
-                AvroContext.get_input_key = AvroContext.deserializing(
-                    AvroContext.get_input_key, reader
+                self.get_input_key = self.deserializing(
+                    self.get_input_key, reader
                 )
             if avro_input == 'V' or avro_input == 'KV':
                 reader = DatumReader(avro.schema.parse(
                     jc.get(AVRO_VALUE_INPUT_SCHEMA)
                 ))
-                AvroContext.get_input_value = AvroContext.deserializing(
-                    AvroContext.get_input_value, reader
+                self.get_input_value = self.deserializing(
+                    self.get_input_value, reader
                 )
         if AVRO_OUTPUT in jc:
             avro_output = jc.get(AVRO_OUTPUT).upper()

--- a/pydoop/mapreduce/pipes.py
+++ b/pydoop/mapreduce/pipes.py
@@ -425,15 +425,17 @@ class StreamRunner(object):
 
 
 def run_task(factory, port=None, istream=None, ostream=None,
-             private_encoding=True, context_class=TaskContext):
+             private_encoding=True, context_class=TaskContext,
+             cmd_file=None):
     """
     Run the assigned task in the framework.
 
     :rtype: bool
     :return: :obj:`True` if the task succeeded.
     """
-    connections = resolve_connections(port,
-                                      istream=istream, ostream=ostream)
+    connections = resolve_connections(
+        port, istream=istream, ostream=ostream, cmd_file=cmd_file
+    )
     context = context_class(connections.up_link, private_encoding)
     stream_runner = StreamRunner(factory, context, connections.cmd_stream)
     stream_runner.run()

--- a/test/avro/all_tests.py
+++ b/test/avro/all_tests.py
@@ -1,0 +1,39 @@
+# BEGIN_COPYRIGHT
+#
+# Copyright 2009-2015 CRS4.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# END_COPYRIGHT
+
+import unittest
+from pydoop.test_utils import get_module
+
+
+TEST_MODULE_NAMES = [
+    'test_context',
+    'test_io',
+]
+
+
+def suite(path=None):
+    suites = []
+    for module in TEST_MODULE_NAMES:
+        suites.append(get_module(module, path).suite())
+    return unittest.TestSuite(suites)
+
+
+if __name__ == '__main__':
+    import sys
+    _RESULT = unittest.TextTestRunner(verbosity=2).run(suite())
+    sys.exit(not _RESULT.wasSuccessful())

--- a/test/avro/common.py
+++ b/test/avro/common.py
@@ -1,0 +1,25 @@
+from cStringIO import StringIO
+
+from avro.io import DatumWriter, BinaryEncoder
+
+
+class AvroSerializer(object):
+
+    def __init__(self, schema):
+        self.schema = schema
+        self.datum_writer = DatumWriter(schema)
+
+    def serialize(self, record):
+        f = StringIO()
+        encoder = BinaryEncoder(f)
+        self.datum_writer.write(record, encoder)
+        return f.getvalue()
+
+
+def avro_user_record(i):
+    return {
+        "office": 'office-%s' % i,
+        "favorite_number": i,
+        "favorite_color": 'color-%s' % i,
+        "name": 'name-%s' % i,
+    }

--- a/test/avro/test_context.py
+++ b/test/avro/test_context.py
@@ -1,0 +1,101 @@
+# BEGIN_COPYRIGHT
+#
+# Copyright 2009-2015 CRS4.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# END_COPYRIGHT
+
+import os
+import unittest
+
+import avro.schema
+
+import pydoop
+import pydoop.mapreduce.api as api
+import pydoop.mapreduce.pipes as pp
+import pydoop.avrolib as avrolib
+from pydoop.test_utils import WDTestCase
+from pydoop.mapreduce.binary_streams import (
+    BinaryWriter, BinaryDownStreamFilter
+)
+
+from common import AvroSerializer, avro_user_record
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class Mapper(api.Mapper):
+
+    def map(self, ctx):
+        r = ctx.value
+        k, v = r['name'], r['favorite_color']
+        print ' * k = %r, v = %r' % (k, v)
+        ctx.emit(k, v)
+
+
+class TestContext(WDTestCase):
+
+    def setUp(self):
+        super(TestContext, self).setUp()
+        with open(os.path.join(THIS_DIR, "user.avsc")) as f:
+            schema = avro.schema.parse(f.read())
+        self.records = [avro_user_record(_) for _ in xrange(3)]
+        serializer = AvroSerializer(schema)
+        #--
+        self.cmd_fn = self._mkfn('map_in')
+        with open(self.cmd_fn, 'w') as f:
+            bwriter = BinaryWriter(f)
+            bwriter.send('start', 0)
+            bwriter.send('setJobConf', (
+                pydoop.PROPERTIES['AVRO_INPUT'], 'V',
+                pydoop.PROPERTIES['AVRO_VALUE_INPUT_SCHEMA'], str(schema)
+            )),
+            bwriter.send('setInputTypes', 'key_type', 'value_type')
+            bwriter.send('runMap', 'input_split', 0, False)
+            for r in self.records:
+                bwriter.send('mapItem', 'k', serializer.serialize(r))
+            bwriter.send('close')
+
+    def tearDown(self):
+        super(TestContext, self).tearDown()
+
+    def runTest(self):
+        print
+        pp.run_task(
+            pp.Factory(mapper_class=Mapper), private_encoding=False,
+            context_class=avrolib.AvroContext, cmd_file=self.cmd_fn
+        )
+        out_fn = self.cmd_fn + '.out'
+        out_records = []
+        with open(out_fn) as ostream:
+            for cmd, args in BinaryDownStreamFilter(ostream):
+                if cmd == 'output':
+                    name, color = args
+                    out_records.append({'name': name, 'favorite_color': color})
+        self.assertEqual(len(out_records), len(self.records))
+        for out_r, r in zip(out_records, self.records):
+            for k, v in out_r.iteritems():
+                self.assertEqual(v, r[k])
+
+
+def suite():
+    suite_ = unittest.TestSuite()
+    suite_.addTest(TestContext('runTest'))
+    return suite_
+
+
+if __name__ == '__main__':
+    _RUNNER = unittest.TextTestRunner(verbosity=2)
+    _RUNNER.run((suite()))

--- a/test/avro/user.avsc
+++ b/test/avro/user.avsc
@@ -1,0 +1,11 @@
+{
+    "namespace": "example.avro",
+    "type": "record",
+    "name": "User",
+    "fields": [
+        {"name": "office", "type": "string"},
+        {"name": "name", "type": "string"},
+        {"name": "favorite_number",  "type": ["int", "null"]},
+        {"name": "favorite_color", "type": ["string", "null"]}
+    ]
+}


### PR DESCRIPTION
See #132. To simplify unit testing, I've also fixed a problem in `mapreduce/pipes`, where there was no way of explicitly passing a command file to `run_task`