### PR TITLE
Fix for #141.

### DIFF
--- a/test/mapreduce/test_framework.py
+++ b/test/mapreduce/test_framework.py
@@ -281,7 +281,8 @@ class TestFramework(WDTestCase):
     def test_map_reduce_comb_with_private_encoding(self):
         factory = TFactory(mapper=TMapperPE, combiner=TCombinerPE,
                            reducer=TReducerPE)
-        self._test_map_reduce_with_private_encoding_helper(factory)
+        self._test_map_reduce_with_private_encoding_helper(factory,
+                                                           fast_combiner=True)
 
     def test_map_reduce_with_private_encoding(self):
         factory = TFactory(mapper=TMapperPE, reducer=TReducerPE)
@@ -290,15 +291,18 @@ class TestFramework(WDTestCase):
     def test_map_reduce_comb_with_side_effect(self):
         factory = TFactory(mapper=TMapperSE, combiner=TCombinerSE,
                            reducer=TReducerSE)
-        self._test_map_reduce_with_private_encoding_helper(factory)
+        self._test_map_reduce_with_private_encoding_helper(factory,
+                                                           fast_combiner=False)
 
-    def _test_map_reduce_with_private_encoding_helper(self, factory):
+    def _test_map_reduce_with_private_encoding_helper(self, factory,
+                                                      fast_combiner=False):
         self.stream3.close()
         cmd_file = self.stream3.name
         out_file = cmd_file + '.out'
         reduce_infile = cmd_file + '.reduce'
         reduce_outfile = reduce_infile + '.out'
-        run_task(factory, cmd_file=cmd_file, private_encoding=True)
+        run_task(factory, cmd_file=cmd_file, private_encoding=True,
+                 fast_combiner=fast_combiner)
         data = {}
         with open(out_file) as f:
             bf = BinaryDownStreamFilter(f)
@@ -357,13 +361,13 @@ class TestFramework(WDTestCase):
 
 def suite():
     suite_ = unittest.TestSuite()
-    suite_.addTest(TestFramework('test_map_only'))
-    suite_.addTest(TestFramework('test_map_reduce'))
-    suite_.addTest(TestFramework('test_map_reduce_comb_with_private_encoding'))
+    # suite_.addTest(TestFramework('test_map_only'))
+    # suite_.addTest(TestFramework('test_map_reduce'))
+    # suite_.addTest(TestFramework('test_map_reduce_comb_with_private_encoding'))
     suite_.addTest(TestFramework('test_map_reduce_comb_with_side_effect'))
-    suite_.addTest(TestFramework('test_map_reduce_with_private_encoding'))
-    suite_.addTest(TestFramework('test_map_combiner_reduce'))
-    suite_.addTest(TestFramework('test_map_combiner_reduce_with_context'))
+    # suite_.addTest(TestFramework('test_map_reduce_with_private_encoding'))
+    # suite_.addTest(TestFramework('test_map_combiner_reduce'))
+    # suite_.addTest(TestFramework('test_map_combiner_reduce_with_context'))
     return suite_
 
 

--- a/test/mapreduce/test_framework.py
+++ b/test/mapreduce/test_framework.py
@@ -201,8 +201,6 @@ class SortAndShuffle(object):
             self.data.setdefault(key, []).append(val)
 
     def write(self, s):
-        import sys
-        sys.stderr.write('s:%r\n' % s)
         self.buffer.append(s)
         if s.endswith('\n'):
             msg = ''.join(self.buffer)
@@ -216,12 +214,8 @@ class SortAndShuffle(object):
         self.out_stream = self.get_reduce_stream()
 
     def readline(self):
-        import sys
         try:
-            v = self.out_stream.next()
-            sys.stderr.write('readline: %r\n' % v)
-            return v
-            # return self.out_stream.next()
+            return self.out_stream.next()
         except StopIteration:
             return ''
 
@@ -361,13 +355,13 @@ class TestFramework(WDTestCase):
 
 def suite():
     suite_ = unittest.TestSuite()
-    # suite_.addTest(TestFramework('test_map_only'))
-    # suite_.addTest(TestFramework('test_map_reduce'))
-    # suite_.addTest(TestFramework('test_map_reduce_comb_with_private_encoding'))
+    suite_.addTest(TestFramework('test_map_only'))
+    suite_.addTest(TestFramework('test_map_reduce'))
+    suite_.addTest(TestFramework('test_map_combiner_reduce'))
+    suite_.addTest(TestFramework('test_map_combiner_reduce_with_context'))
+    suite_.addTest(TestFramework('test_map_reduce_with_private_encoding'))
+    suite_.addTest(TestFramework('test_map_reduce_comb_with_private_encoding'))
     suite_.addTest(TestFramework('test_map_reduce_comb_with_side_effect'))
-    # suite_.addTest(TestFramework('test_map_reduce_with_private_encoding'))
-    # suite_.addTest(TestFramework('test_map_combiner_reduce'))
-    # suite_.addTest(TestFramework('test_map_combiner_reduce_with_context'))
     return suite_
 
 


### PR DESCRIPTION
Implemented a strictly defensive strategy that considers as immutable
only numbers and strings. Everything else, we deepcopy.

This can be by-passed, at user peril, by setting  'fast_combiner=True'
in run_task.