### PR TITLE
No separator output format for all MR versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,7 @@ install:
 
 script:
 - cd test;
+- top -b -n 1 -c # run top in batch mode, 1 iteration, show command. top on Travis doesn't support sort (-o)
 - $VIRTUAL_ENV/bin/python all_tests.py
 - cd ../examples
 - export PYTHONBIN=$VIRTUAL_ENV/bin/python

--- a/.travis/install_hadoop.sh
+++ b/.travis/install_hadoop.sh
@@ -178,14 +178,11 @@ export LIBHDFS_OPTS="-Xmx96m"\
 
     if [[ "${Yarn}" == true ]]; then  # MRv2 (YARN)
         ## hdfs-site.xml
-        sudo sed '/\/configuration/ i\<property><name>dfs.permissions.supergroup<\/name><value>admin<\/value><\/property><property><name>dfs.namenode.fs-limits.min-block-size</name><value>512</value></property>' <  /etc/hadoop/conf/hdfs-site.xml > /tmp/hdfs-site.xml;
-        sudo mv /tmp/hdfs-site.xml /etc/hadoop/conf/hdfs-site.xml
+        sudo sed -i -e '/\/configuration/ i\<property><name>dfs.permissions.supergroup<\/name><value>admin<\/value><\/property><property><name>dfs.namenode.fs-limits.min-block-size</name><value>512</value></property>' /etc/hadoop/conf/hdfs-site.xml
         ## mapred-site.xml
-        sudo sed '/\/configuration/ i\<property><name>mapreduce.framework.name</name><value>yarn</value></property><property><name>mapreduce.task.timeout</name><value>60000</value></property><property><name>mapred.task.timeout</name><value>60000</value></property>' <  /etc/hadoop/conf/mapred-site.xml > /tmp/mapred-site.xml;
-        sudo mv /tmp/mapred-site.xml /etc/hadoop/conf/mapred-site.xml
+        sudo sed -i -e '/\/configuration/ i\<property><name>mapreduce.framework.name</name><value>yarn</value></property><property><name>mapreduce.task.timeout</name><value>60000</value></property><property><name>mapred.task.timeout</name><value>60000</value></property>' /etc/hadoop/conf/mapred-site.xml
         ## yarn-site.xml
-        sudo sed '/\/configuration/ i\<property><name>yarn.nodemanager.vmem-pmem-ratio</name><value>2.8</value></property>' <  /etc/hadoop/conf/yarn-site.xml > /tmp/yarn-site.xml;
-        sudo mv /tmp/yarn-site.xml /etc/hadoop/conf/yarn-site.xml
+        sudo sed -i -e '/\/configuration/ i\<property><name>yarn.nodemanager.vmem-pmem-ratio</name><value>2.8</value></property>' /etc/hadoop/conf/yarn-site.xml
     else  # MRv1
         write_cdh_mrv1_config "${HadoopConfDir}"
     fi

--- a/.travis/install_hadoop.sh
+++ b/.travis/install_hadoop.sh
@@ -179,15 +179,15 @@ export LIBHDFS_OPTS="-Xmx96m"\
     if [[ "${Yarn}" == true ]]; then  # MRv2 (YARN)
         ## hdfs-site.xml
         sudo sed '/\/configuration/ i\<property><name>dfs.permissions.supergroup<\/name><value>admin<\/value><\/property><property><name>dfs.namenode.fs-limits.min-block-size</name><value>512</value></property>' <  /etc/hadoop/conf/hdfs-site.xml > /tmp/hdfs-site.xml;
-	    sudo mv /tmp/hdfs-site.xml /etc/hadoop/conf/hdfs-site.xml
+        sudo mv /tmp/hdfs-site.xml /etc/hadoop/conf/hdfs-site.xml
         ## mapred-site.xml
-	    sudo sed '/\/configuration/ i\<property><name>mapreduce.framework.name</name><value>yarn</value></property><property><name>mapreduce.task.timeout</name><value>60000</value></property><property><name>mapred.task.timeout</name><value>60000</value></property>' <  /etc/hadoop/conf/mapred-site.xml > /tmp/mapred-site.xml;
-	    sudo mv /tmp/mapred-site.xml /etc/hadoop/conf/mapred-site.xml
+        sudo sed '/\/configuration/ i\<property><name>mapreduce.framework.name</name><value>yarn</value></property><property><name>mapreduce.task.timeout</name><value>60000</value></property><property><name>mapred.task.timeout</name><value>60000</value></property>' <  /etc/hadoop/conf/mapred-site.xml > /tmp/mapred-site.xml;
+        sudo mv /tmp/mapred-site.xml /etc/hadoop/conf/mapred-site.xml
         ## yarn-site.xml
-	    sudo sed '/\/configuration/ i\<property><name>yarn.nodemanager.vmem-pmem-ratio</name><value>2.8</value></property>' <  /etc/hadoop/conf/yarn-site.xml > /tmp/yarn-site.xml;
-	    sudo mv /tmp/yarn-site.xml /etc/hadoop/conf/yarn-site.xml
+        sudo sed '/\/configuration/ i\<property><name>yarn.nodemanager.vmem-pmem-ratio</name><value>2.8</value></property>' <  /etc/hadoop/conf/yarn-site.xml > /tmp/yarn-site.xml;
+        sudo mv /tmp/yarn-site.xml /etc/hadoop/conf/yarn-site.xml
     else  # MRv1
-	    write_cdh_mrv1_config "${HadoopConfDir}"
+        write_cdh_mrv1_config "${HadoopConfDir}"
     fi
 
     # update the hadoop_env
@@ -211,7 +211,7 @@ function install_standard_hadoop() {
         export HADOOP_BIN="${HADOOP_HOME}/sbin/"
         export HADOOP_COMMON_LIB_NATIVE_DIR="${HADOOP_HOME}/lib/native"
         export HADOOP_OPTS="-Djava.library.path=${HADOOP_HOME}/lib"
-    else 
+    else
         export HADOOP_CONF_DIR="${HADOOP_HOME}/conf"
         export HADOOP_BIN="${HADOOP_HOME}/bin/"
         write_hadoop_standard_config_v1 "${HADOOP_CONF_DIR}"
@@ -224,7 +224,7 @@ function install_standard_hadoop() {
     if [[ -n "${PYTHONPATH}" ]]; then
       echo "export PYTHONPATH=${PYTHONPATH}" >> "${HADOOP_CONF_DIR}/hadoop-env.sh"
     fi
-    
+
     log "Formatting namenode"
     "${HADOOP_HOME}/bin/hadoop" namenode -format
     log "Starting daemons..."
@@ -339,46 +339,46 @@ function install_hdp2() {
     [ $# -eq 1 ] || error "Missing HadoopVersion"
     local HadoopVersion="${1}"
     local HRTWRKS_VER="${HadoopVersion##HDP}"
-    
+
     log "Installing Hortonworks Hadoop, version ${HadoopVersion}: START"
-    
+
     install_hdp2_ubuntu_packages ${HRTWRKS_VER}
-    
+
     if [ "$HadoopVersion" = "HDP2.2.0.0" ]; then
         #local HadoopConfDir=/usr/hdp/2.2.0.0-2041/hadoop/conf
         local HadoopConfDir=/etc/hadoop/conf
         local HDP_BASE=/usr/hdp/current/
         local HDP_NMND=${HDP_BASE}/hadoop-hdfs-namenode
-        local HDFS=${HDP_NMND}/../hadoop/bin/hdfs        
+        local HDFS=${HDP_NMND}/../hadoop/bin/hdfs
         local HDFS_DAEMON=${HDP_NMND}/../hadoop/sbin/hadoop-daemon.sh
         local YARN_DAEMON=${HDP_BASE}/hadoop-yarn-nodemanager/sbin/yarn-daemon.sh
 
-        log "Copying new conf in ${HadoopConfDir}"        
+        log "Copying new conf in ${HadoopConfDir}"
         sudo -E cp ${PWD}/.travis/hadoop-2.6.0-conf/* ${HadoopConfDir}/
         log "Current contents of ${HadoopConfDir}"
         ls -lR ${HadoopConfDir}/
-        
+
         log "Formatting the NameNode"
         sudo -E ${HDFS} namenode -format
         log "Start HDFS"
         sudo -E ${HDFS_DAEMON} start namenode
         sudo -E ${HDFS_DAEMON} start datanode
-        sudo -E ${YARN_DAEMON} start resourcemanager        
+        sudo -E ${YARN_DAEMON} start resourcemanager
         sudo -E ${YARN_DAEMON} start nodemanager
     elif [ "$HadoopVersion" = "HDP2.1.5.0" ]; then
         # Currently broken.
-        export HADOOP_CONF_DIR="${PWD}/.travis/hadoop-2.6.0-conf/"    
+        export HADOOP_CONF_DIR="${PWD}/.travis/hadoop-2.6.0-conf/"
         log "Adding mixing links"
         ln -s /usr/lib/hadoop/libexec /usr/lib/hadoop-hdfs/
         ln -s /usr/lib/hadoop/libexec /usr/lib/hadoop-yarn/
-    
+
         log "Formatting the NameNode"
         /usr/lib/hadoop-hdfs/bin/hdfs --config /shared/hadoop-conf  namenode -format
 
         log "Start HDFS"
         /usr/lib/hadoop/sbin/hadoop-daemon.sh --config $HADOOP_CONF_DIR start namenode
         /usr/lib/hadoop/sbin/hadoop-daemon.sh --config $HADOOP_CONF_DIR start datanode
-        log "Start yarn"    
+        log "Start yarn"
         /usr/lib/hadoop-yarn/sbin/yarn-daemon.sh --config /shared/hadoop-conf start resourcemanager
         /usr/lib/hadoop-yarn/sbin/yarn-daemon.sh --config /shared/hadoop-conf start nodemanager
     fi

--- a/examples/input_format/run
+++ b/examples/input_format/run
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-set -o errexit
-set -o nounset
-
 PYTHONBIN=${PYTHONBIN:-python}
 
-CHK="import pydoop; hd_info = pydoop.hadoop_version_info(); print(hd_info.has_mrv2())"
+CHK="import pydoop; hd_info = pydoop.hadoop_version_info(); print(hd_info.tuple >= (2, 2, 0) and hd_info.is_yarn())"
 is_mrv2_ok=`${PYTHONBIN} -c "$CHK"`
 
 if [[ x${is_mrv2_ok} == xTrue ]]; then

--- a/examples/input_format/run
+++ b/examples/input_format/run
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+set -o errexit
+set -o nounset
+
 PYTHONBIN=${PYTHONBIN:-python}
 
-CHK="import pydoop; hd_info = pydoop.hadoop_version_info(); print(hd_info.tuple >= (2, 2, 0) and hd_info.is_yarn())"
+CHK="import pydoop; hd_info = pydoop.hadoop_version_info(); print(hd_info.has_mrv2())"
 is_mrv2_ok=`${PYTHONBIN} -c "$CHK"`
 
 if [[ x${is_mrv2_ok} == xTrue ]]; then

--- a/examples/pydoop_submit/run_nosep
+++ b/examples/pydoop_submit/run_nosep
@@ -12,7 +12,7 @@ fi
 SUBMIT_CMD="pydoop submit"
 MODULE=col0
 MPY=${MODULE}.py
-OUTPUT_FORMAT=it.crs4.pydoop.mapreduce.lib.output.NoSeparatorTextOutputFormat
+OUTPUT_FORMAT=it.crs4.pydoop.NoSeparatorTextOutputFormat
 
 LOGLEVEL=INFO
 MRV=--mrv2

--- a/pydoop/app/script.py
+++ b/pydoop/app/script.py
@@ -87,7 +87,7 @@ class PydoopScript(object):
         args.cache_archive = None
         args.upload_to_cache = None
         args.libjars = None
-        args.mrv2 = False
+        args.mrv2 = pydoop.hadoop_version_info().has_mrv2()
         args.local_fs = False
         args.conf = None
         args.disable_property_name_conversion = True
@@ -95,6 +95,7 @@ class PydoopScript(object):
                           args.kv_separator)]
         args.avro_input = None
         args.avro_output = None
+
         # despicable hack...
         properties = dict(args.D or [])
         properties.update(dict(args.job_conf))

--- a/pydoop/hadoop_utils.py
+++ b/pydoop/hadoop_utils.py
@@ -260,6 +260,11 @@ class HadoopVersion(object):
         return (self.distribution == 'cdh' and
                 self.dist_version >= (4, 0, 0) and not self.dist_ext)
 
+    def has_mrv2(self):
+        return \
+            self.main >= (2, 0, 0) and \
+                (self.is_yarn() or not self.is_cloudera())
+
     def is_cdh_v5(self):
         return (self.distribution == 'cdh' and
                 self.dist_version >= (5, 0, 0) and

--- a/pydoop/hadoop_utils.py
+++ b/pydoop/hadoop_utils.py
@@ -262,8 +262,8 @@ class HadoopVersion(object):
 
     def has_mrv2(self):
         return \
-            self.main >= (2, 0, 0) and \
-                (self.is_yarn() or not self.is_cloudera())
+            self.main >= (2, 0, 0) and self.is_yarn() and \
+                (not self.is_cloudera() or (self.is_cloudera() and self.dist_version >= (5, 0, 0)))
 
     def is_cdh_v5(self):
         return (self.distribution == 'cdh' and

--- a/setup.py
+++ b/setup.py
@@ -391,6 +391,13 @@ class Clean(clean):
         ]
         for p in garbage_list:
             rm_rf(p, self.dry_run)
+        self._clean_examples()
+
+    @staticmethod
+    def _clean_examples():
+        for root, _, files in os.walk('examples'):
+            if 'Makefile' in files:
+                subprocess.call(["make", "-C", root, "clean" ])
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -235,9 +235,7 @@ class JavaLib(object):
         self.java_files = []
         self.dependencies = []
         self.properties = []
-        if (hadoop_vinfo.main >= (2, 0, 0)
-            and (not hadoop_vinfo.is_cloudera()
-                 or hadoop_vinfo.is_yarn())):
+        if hadoop_vinfo.has_mrv2():
             # FIXME: kinda hardwired to avro for now
             self.properties.append((os.path.join(
                 "it/crs4/pydoop/mapreduce/pipes", PROP_BN),

--- a/setup.py
+++ b/setup.py
@@ -242,9 +242,8 @@ class JavaLib(object):
             self.properties.append((os.path.join(
                 "it/crs4/pydoop/mapreduce/pipes", PROP_BN),
                 PROP_FN))
-            # -- pydoop script is currently using v1
             self.java_files.extend([
-                "src/v1/it/crs4/pydoop/NoSeparatorTextOutputFormat.java"
+                "src/v2/it/crs4/pydoop/NoSeparatorTextOutputFormat.java"
             ])
             self.java_files.extend(glob.glob(
                 'src/v2/it/crs4/pydoop/pipes/*.java'

--- a/setup.py
+++ b/setup.py
@@ -247,6 +247,8 @@ class JavaLib(object):
             self.java_files.extend(glob.glob(
                 'src/v2/it/crs4/pydoop/mapreduce/pipes/*.java'
             ))
+            # for things such as avro-mapreduce
+            self.dependencies.extend(glob.glob('lib/*.jar'))
         else:
             # Else we should be dealing with v1 pipes
             self.java_files.extend(glob.glob(
@@ -261,8 +263,6 @@ class JavaLib(object):
             self.java_files.extend([
                 "src/v2/it/crs4/pydoop/NoSeparatorTextOutputFormat.java"
             ])
-            # for things such as avro-mapreduce
-            self.dependencies.extend(glob.glob('lib/*.jar'))
         else:
             self.java_files.extend([
                 "src/v1/it/crs4/pydoop/NoSeparatorTextOutputFormat.java"

--- a/setup.py
+++ b/setup.py
@@ -235,32 +235,38 @@ class JavaLib(object):
         self.java_files = []
         self.dependencies = []
         self.properties = []
-        if hadoop_vinfo.has_mrv2():
+        if hadoop_vinfo.main >= (2, 0, 0) and hadoop_vinfo.is_yarn():
+            # This version of Hadoop has the v2 pipes API
             # FIXME: kinda hardwired to avro for now
             self.properties.append((os.path.join(
                 "it/crs4/pydoop/mapreduce/pipes", PROP_BN),
                 PROP_FN))
-            self.java_files.extend([
-                "src/v2/it/crs4/pydoop/NoSeparatorTextOutputFormat.java"
-            ])
             self.java_files.extend(glob.glob(
                 'src/v2/it/crs4/pydoop/pipes/*.java'
             ))
             self.java_files.extend(glob.glob(
                 'src/v2/it/crs4/pydoop/mapreduce/pipes/*.java'
             ))
+        else:
+            # Else we should be dealing with v1 pipes
+            self.java_files.extend(glob.glob(
+                'src/v1/org/apache/hadoop/mapred/pipes/*.java'
+            ))
+
+        if hadoop_vinfo.has_mrv2():
+            # If the installation has MRv2 we need to use v2 I/O classes
             self.java_files.extend(glob.glob(
                 'src/v2/it/crs4/pydoop/mapreduce/lib/output/*.java'
             ))
-            # for now we have only hadoop2 deps (avro-mapred)
+            self.java_files.extend([
+                "src/v2/it/crs4/pydoop/NoSeparatorTextOutputFormat.java"
+            ])
+            # for things such as avro-mapreduce
             self.dependencies.extend(glob.glob('lib/*.jar'))
         else:
             self.java_files.extend([
                 "src/v1/it/crs4/pydoop/NoSeparatorTextOutputFormat.java"
             ])
-            self.java_files.extend(glob.glob(
-                'src/v1/org/apache/hadoop/mapred/pipes/*.java'
-            ))
 
 
 class JavaBuilder(object):

--- a/src/v2/it/crs4/pydoop/NoSeparatorTextOutputFormat.java
+++ b/src/v2/it/crs4/pydoop/NoSeparatorTextOutputFormat.java
@@ -17,7 +17,7 @@
 // 
 // END_COPYRIGHT
 
-package it.crs4.pydoop.mapreduce.lib.output;
+package it.crs4.pydoop;
 
 import java.io.DataOutputStream;
 import java.io.IOException;


### PR DESCRIPTION
This PR's main contribution is to enable the use of the `NoSeparatorOutputFormat` with both MR versions.    In additiont to changing the output format's package, the PR revisits the compilation rules to try to appropriately decide when to bundle MRv1 or MRv2 I/O formats and pipes classes, depending on the Hadoop version against which Pydoop is being compiled.  Pydoop `script` is modified to select MRv1 or v2 depending on the version of Hadoop being used (the user can always request a preferred version from the command line).

The PR also lowers the heap sizes allocated by CDH on travis to try to reduce the number of run failures due to lack of memory.  CDH5 is still problematic and fails quite often (but all tests passed before creating this pull request!)