### PR TITLE
Fix hadut

### DIFF
--- a/docs/api_docs/hadut.rst
+++ b/docs/api_docs/hadut.rst
@@ -1,0 +1,7 @@
+.. _hadut:
+
+:mod:`pydoop.hadut` --- Hadoop shell interaction
+================================================
+
+.. automodule:: pydoop.hadut
+   :members:

--- a/docs/api_docs/index.rst
+++ b/docs/api_docs/index.rst
@@ -10,3 +10,4 @@ Contents:
    mr_api
    hdfs_api
    simulator
+   hadut

--- a/pydoop/app/submit.py
+++ b/pydoop/app/submit.py
@@ -373,16 +373,16 @@ class PydoopSubmitter(object):
                         else self.fake_run_class)
             executor(submitter_class, args=job_args,
                      properties=self.properties, classpath=classpath,
-                     logger=self.logger)
+                     logger=self.logger, keep_streams=False)
             self.logger.info("Done")
         finally:
             self.__clean_wd()
 
-    def fake_run_class(self, submitter_class, args, properties, classpath,
-                       logger):
-        logger.info("Fake run class")
-        sys.stdout.write("hadut.run_class(%s, %s, %s, %s)\n" %
-                         (submitter_class, args, properties, classpath))
+    def fake_run_class(self, *args, **kwargs):
+        kwargs['logger'].info("Fake run class")
+        repr_list = map(repr, args)
+        repr_list.extend('%s=%r' % (k, v) for k, v in kwargs.iteritems())
+        sys.stdout.write("hadut.run_class(%s)\n" % ', '.join(repr_list))
 
 
 def run(args, unknown_args=None):

--- a/pydoop/hadut.py
+++ b/pydoop/hadut.py
@@ -134,21 +134,7 @@ def run_cmd(cmd, args=None, properties=None, hadoop_home=None,
 
     .. code-block:: python
 
-      >>> import uuid
-      >>> properties = {'dfs.block.size': 32*2**20}
-      >>> args = ['-put', 'hadut.py', uuid.uuid4().hex]
-      >>> res = run_cmd('fs', args, properties)
-      >>> res
-      ''
-      >>> print run_cmd('dfsadmin', ['-help', 'report'])
-      -report: Reports basic filesystem information and statistics.
-      >>> try:
-      ...     run_cmd('foo')
-      ... except RunCmdError as e:
-      ...     print e
-      ...
-      Exception in thread "main" java.lang.NoClassDefFoundError: foo
-      ...
+      >>> hadoop_classpath = run_cmd('classpath')
     """
     if logger is None:
         logger = utils.NullLogger()
@@ -258,21 +244,6 @@ def run_jar(jar_name, more_args=None, properties=None, hadoop_conf_dir=None,
 
     ``more_args`` (after prepending ``jar_name``) and ``properties`` are
     passed to :func:`run_cmd`.
-
-    .. code-block:: python
-
-      >>> import glob, pydoop
-      >>> hadoop_home = pydoop.hadoop_home()
-      >>> v = pydoop.hadoop_version_info()
-      >>> if v.cdh >= (4, 0, 0): hadoop_home += '-0.20-mapreduce'
-      >>> jar_name = glob.glob('%s/*examples*.jar' % hadoop_home)[0]
-      >>> more_args = ['wordcount']
-      >>> try:
-      ...     run_jar(jar_name, more_args=more_args)
-      ... except RunCmdError as e:
-      ...     print e
-      ...
-      Usage: wordcount <in> <out>
     """
     if hu.is_readable(jar_name):
         args = [jar_name]
@@ -299,9 +270,10 @@ def run_class(class_name, args=None, properties=None, classpath=None,
 
     .. code-block:: python
 
-      >>> cls = 'org.apache.hadoop.hdfs.tools.DFSAdmin'
-      >>> print run_class(cls, args=['-help', 'report'])
-      -report: Reports basic filesystem information and statistics.
+      >>> cls = 'org.apache.hadoop.fs.FsShell'
+      >>> try: out = run_class(cls, args=['-test', '-e', 'file:/tmp'])
+      ... except RunCmdError: tmp_exists = False
+      ... else: tmp_exists = True
 
     .. note::
 

--- a/pydoop/hadut.py
+++ b/pydoop/hadut.py
@@ -17,8 +17,8 @@
 # END_COPYRIGHT
 
 """
-The hadut module provides access to some Hadoop functionalities
-available via the Hadoop shell.
+The hadut module provides access to some functionalities available
+via the Hadoop shell.
 """
 
 import os


### PR DESCRIPTION
This PR's main contribution is to add a new boolean `keep_streams` kwarg to `hadut.run_cmd`. Setting `keep_streams` to `False` allows to turn off stdout/err redirection in the underlying subprocess call, which is what you want when you're running a job (you get periodic updates on the shell, instead of nothing until the job ends). For a more detailed description of the new kwarg, see the docstring.