### PR TITLE
HADOOP_PREFIX and other fixes 

### DIFF
--- a/.travis/install_hadoop.sh
+++ b/.travis/install_hadoop.sh
@@ -159,14 +159,14 @@ function update_cdh_config_files(){
     # MemoryErrors in the tests).
     sudo sed -i \
       -e '/^export HADOOP_[A-Z]\+_OPTS/s/-Xmx[0-9]\+m\>/-Xmx128m/' \
-      -e '/HADOOP_.*HEAPSIZE=/s/^.*\(\<HADOOP_[A-Z_]*HEAPSIZE\)=.*/export \1=400/'
+      -e '/HADOOP_.*HEAPSIZE=/s/^.*\(\<HADOOP_[A-Z_]*HEAPSIZE\)=.*/export \1=400/' \
       -e '$a\
 export LIBHDFS_OPTS="-Xmx96m"\
 ' \
       "${HadoopConfDir}/hadoop-env.sh"
 
     sudo sed -i \
-      -e '/\<YARN_.*HEAPSIZE=/s/^.*\(\<YARN_[A-Z_]*HEAPSIZE\)=.*/export \1=256/'
+      -e '/\<YARN_.*HEAPSIZE=/s/^.*\(\<YARN_[A-Z_]*HEAPSIZE\)=.*/export \1=256/' \
       "${HadoopConfDir}/yarn-env.sh"
 
     sudo sed -i \

--- a/pydoop/hadoop_utils.py
+++ b/pydoop/hadoop_utils.py
@@ -319,11 +319,17 @@ class HadoopVersion(object):
 
 
 def is_exe(fpath):
-    return os.path.exists(fpath) and os.access(fpath, os.X_OK)
+    """
+    Path references an executable file.
+    """
+    return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
 
 
 def is_readable(fpath):
-    return os.path.exists(fpath) and os.access(fpath, os.R_OK)
+    """
+    Path references a readable file.
+    """
+    return os.path.isfile(fpath) and os.access(fpath, os.R_OK)
 
 
 def extract_text(node):

--- a/pydoop/hadoop_utils.py
+++ b/pydoop/hadoop_utils.py
@@ -425,12 +425,12 @@ class PathFinder(object):
                 first_dir_in_glob("/opt/hadoop*")
             )
         if not self.__hadoop_home:
-            PathFinder.__error("hadoop home", "HADOOP_HOME")
+            PathFinder.__error("hadoop home", "HADOOP_PREFIX or HADOOP_HOME")
         return self.__hadoop_home
 
     def mapred_exec(self, hadoop_home=None):
         if not self.__mapred_exec:
-            if not (hadoop_home or os.getenv("HADOOP_HOME")):
+            if not (hadoop_home or os.getenv("HADOOP_PREFIX", os.getenv("HADOOP_HOME"))):
                 if is_exe(self.CDH_HADOOP_EXEC):
                     self.__mapred_exec = self.CDH_HADOOP_EXEC
             else:
@@ -446,7 +446,7 @@ class PathFinder(object):
     def hadoop_exec(self, hadoop_home=None):
         if not self.__hadoop_exec:
             # allow overriding of package-installed hadoop exec
-            if not (hadoop_home or os.getenv("HADOOP_HOME")):
+            if not (hadoop_home or os.getenv("HADOOP_PREFIX", os.getenv("HADOOP_HOME"))):
                 if is_exe(self.CDH_HADOOP_EXEC):
                     self.__hadoop_exec = self.CDH_HADOOP_EXEC
             else:
@@ -456,7 +456,7 @@ class PathFinder(object):
                 if is_exe(fn):
                     self.__hadoop_exec = fn
         if not self.__hadoop_exec:
-            PathFinder.__error("hadoop executable", "HADOOP_HOME or PATH")
+            PathFinder.__error("hadoop executable", "HADOOP_PREFIX or HADOOP_HOME or PATH")
         return self.__hadoop_exec
 
     def hadoop_version(self, hadoop_home=None):
@@ -471,6 +471,8 @@ class PathFinder(object):
                 else:
                     try:
                         env = os.environ.copy()
+                        # why pop HADOOP_HOME?
+                        env.pop("HADOOP_PREFIX", None)
                         env.pop("HADOOP_HOME", None)
                         p = sp.Popen([hadoop, "version"], stdout=sp.PIPE,
                                      stderr=sp.PIPE, env=env)


### PR DESCRIPTION
This branch fixes the missing check of HADOOP_PREFIX env var in PathFinder.hadoop_exec and PathFinder.mapred_exec, previously only HADOOP_HOME was checked. It also fixes some missing backslashes in .travis/install_hadoop.sh and is_exe/is_readable function in hadoop_utils.py, that returned  True in case of directory