### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/docs/ideas_list.rst
+++ b/docs/ideas_list.rst
@@ -38,7 +38,7 @@ implementation in Python.
 Python 3 porting
 ----------------
 
-Pydoop currently runs on Python 2.7 (and 2.6, with some backports). It
+Pydoop currently runs on Python 2.7. It
 would be nice to make it available to Python 3 users.
 
 **Knowledge prerequisites:** Python 2, Python 3

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,8 +55,7 @@ Prerequisites
 
 In order to build and install Pydoop, you need the following software:
 
-* `Python <http://www.python.org>`_ version 2.7 (or 2.6 with
-  backports [#]_)
+* `Python <http://www.python.org>`_ version 2.7
 
 * `setuptools <https://pypi.python.org/pypi/setuptools>`_ version 3.3
   or higher
@@ -311,11 +310,3 @@ a low value:
   </property>
 
 then restart Hadoop daemons.
-
-
-.. rubric:: Footnotes
-
-.. [#] To make Pydoop work with Python 2.6 you need to install the
-   following additional modules: `importlib
-   <http://pypi.python.org/pypi/importlib>`_ and `argparse
-   <http://pypi.python.org/pypi/argparse>`_.

--- a/setup.py
+++ b/setup.py
@@ -418,7 +418,6 @@ setup(
     download_url="https://pypi.python.org/pypi/pydoop",
     install_requires=['setuptools>=%s' % SETUPTOOLS_MIN_VER],
     extras_require={
-        ':python_version=="2.6"': ['argparse', 'importlib'],
         'avro': ["avro>=1.7.4"],
         },
     packages=find_packages(exclude=['test', 'test.*']),


### PR DESCRIPTION
Python 2.7 is now the default in all major distributions. By dropping support for Python 2.6, the Pydoop team will have more time to concentrate on new features and bug fixing.