### PR TITLE
bump copyright end year

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@
 Pydoop is a Python MapReduce and HDFS API for
 [Hadoop](http://hadoop.apache.org/).
 
-Copyright 2009-2015 [CRS4](http://www.crs4.it/).
+Copyright 2009-2016 [CRS4](http://www.crs4.it/).
 
 To get started, take a look at [the docs](http://crs4.github.io/pydoop/).

--- a/dev_tools/bump_copyright_year
+++ b/dev_tools/bump_copyright_year
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+"""\
+Set copyright end year across the distribution.
+"""
+
+import sys
+import os
+import re
+import argparse
+import datetime
+
+
+THIS_YEAR = datetime.date.today().year
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+PATTERN = re.compile(r"(?<=opyright 2009-)\d+")
+
+
+def find_files(root_dir):
+    for d, subdirs, fnames in os.walk(root_dir, topdown=True):
+        for fn in fnames:
+            yield os.path.join(d, fn)
+        subdirs[:] = [_ for _ in subdirs if _ != ".git"]
+
+
+def bump_end_year(root_dir, year):
+    year = "%d" % year
+    for fn in find_files(root_dir):
+        if fn == os.path.abspath(__file__):
+            continue
+        print "processing %r" % (fn,)
+        with open(fn) as f:
+            content = f.read()
+        with open(fn, "w") as f:
+            f.write(re.sub(PATTERN, year, content))
+
+
+def make_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-y", type=int, metavar="YYYY", default=THIS_YEAR,
+                        help="copyright end year (default = current)")
+    return parser
+
+
+def main(argv):
+    parser = make_parser()
+    args = parser.parse_args(argv[1:])
+    repo_root = os.path.dirname(THIS_DIR)
+    bump_end_year(repo_root, args.y)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/examples/avro/java/src/main/java/it/crs4/pydoop/WriteKV.java
+++ b/examples/avro/java/src/main/java/it/crs4/pydoop/WriteKV.java
@@ -1,6 +1,6 @@
 /** BEGIN_COPYRIGHT
  *
- * Copyright 2009-2015 CRS4.
+ * Copyright 2009-2016 CRS4.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/java/src/main/java/it/crs4/pydoop/WriteParquet.java
+++ b/examples/avro/java/src/main/java/it/crs4/pydoop/WriteParquet.java
@@ -1,6 +1,6 @@
 /* BEGIN_COPYRIGHT
  *
- * Copyright 2009-2015 CRS4.
+ * Copyright 2009-2016 CRS4.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/avro_base.py
+++ b/examples/avro/py/avro_base.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/avro_key_in.py
+++ b/examples/avro/py/avro_key_in.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/avro_key_in_out.py
+++ b/examples/avro/py/avro_key_in_out.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/avro_key_value_in.py
+++ b/examples/avro/py/avro_key_value_in.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/avro_key_value_in_out.py
+++ b/examples/avro/py/avro_key_value_in_out.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/avro_parquet_dump_results.py
+++ b/examples/avro/py/avro_parquet_dump_results.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/avro_pyrw.py
+++ b/examples/avro/py/avro_pyrw.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/avro_value_in.py
+++ b/examples/avro/py/avro_value_in.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/avro_value_in_out.py
+++ b/examples/avro/py/avro_value_in_out.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/check_results.py
+++ b/examples/avro/py/check_results.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/color_count.py
+++ b/examples/avro/py/color_count.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/create_input.py
+++ b/examples/avro/py/create_input.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/gen_data.py
+++ b/examples/avro/py/gen_data.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/kmer_count.py
+++ b/examples/avro/py/kmer_count.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/avro/py/simulate_cc.py
+++ b/examples/avro/py/simulate_cc.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/hdfs/common.py
+++ b/examples/hdfs/common.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/hdfs/run
+++ b/examples/hdfs/run
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 # 
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/hdfs/treegen.py
+++ b/examples/hdfs/treegen.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/hdfs/treewalk.py
+++ b/examples/hdfs/treewalk.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/input_format/Makefile
+++ b/examples/input_format/Makefile
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 # 
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/input_format/check_results.py
+++ b/examples/input_format/check_results.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/input_format/it/crs4/pydoop/mapred/TextInputFormat.java
+++ b/examples/input_format/it/crs4/pydoop/mapred/TextInputFormat.java
@@ -1,6 +1,6 @@
 // BEGIN_COPYRIGHT
 // 
-// Copyright 2009-2015 CRS4.
+// Copyright 2009-2016 CRS4.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy

--- a/examples/input_format/it/crs4/pydoop/mapreduce/TextInputFormat.java
+++ b/examples/input_format/it/crs4/pydoop/mapreduce/TextInputFormat.java
@@ -1,6 +1,6 @@
 // BEGIN_COPYRIGHT
 // 
-// Copyright 2009-2015 CRS4.
+// Copyright 2009-2016 CRS4.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy

--- a/examples/input_format/wordcount_rr.py
+++ b/examples/input_format/wordcount_rr.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/pydoop_script/base_histogram.py
+++ b/examples/pydoop_script/base_histogram.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/pydoop_script/caseswitch.py
+++ b/examples/pydoop_script/caseswitch.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/pydoop_script/file_system_scanner
+++ b/examples/pydoop_script/file_system_scanner
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/pydoop_script/grep.py
+++ b/examples/pydoop_script/grep.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/pydoop_script/lowercase.py
+++ b/examples/pydoop_script/lowercase.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/pydoop_script/run_base_histogram
+++ b/examples/pydoop_script/run_base_histogram
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/pydoop_script/run_caseswitch
+++ b/examples/pydoop_script/run_caseswitch
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/pydoop_script/run_grep
+++ b/examples/pydoop_script/run_grep
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/pydoop_script/run_grep_compiled
+++ b/examples/pydoop_script/run_grep_compiled
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/pydoop_script/run_lowercase
+++ b/examples/pydoop_script/run_lowercase
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/pydoop_script/run_transpose
+++ b/examples/pydoop_script/run_transpose
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/pydoop_script/transpose.py
+++ b/examples/pydoop_script/transpose.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/self_contained/Makefile
+++ b/examples/self_contained/Makefile
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 # 
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/self_contained/check_results.py
+++ b/examples/self_contained/check_results.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/self_contained/vowelcount/__init__.py
+++ b/examples/self_contained/vowelcount/__init__.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/self_contained/vowelcount/lib/__init__.py
+++ b/examples/self_contained/vowelcount/lib/__init__.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/self_contained/vowelcount/mr/__init__.py
+++ b/examples/self_contained/vowelcount/mr/__init__.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/self_contained/vowelcount/mr/main.py
+++ b/examples/self_contained/vowelcount/mr/main.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/self_contained/vowelcount/mr/mapper.py
+++ b/examples/self_contained/vowelcount/mr/mapper.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/self_contained/vowelcount/mr/reducer.py
+++ b/examples/self_contained/vowelcount/mr/reducer.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/sequence_file/bin/filter.py
+++ b/examples/sequence_file/bin/filter.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/sequence_file/bin/wordcount.py
+++ b/examples/sequence_file/bin/wordcount.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/sequence_file/run
+++ b/examples/sequence_file/run
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/simulator/run
+++ b/examples/simulator/run
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/wordcount/bin/wordcount-full.py
+++ b/examples/wordcount/bin/wordcount-full.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/wordcount/bin/wordcount-minimal.py
+++ b/examples/wordcount/bin/wordcount-minimal.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/wordcount/new_api/wordcount_full.py
+++ b/examples/wordcount/new_api/wordcount_full.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/wordcount/new_api/wordcount_minimal.py
+++ b/examples/wordcount/new_api/wordcount_minimal.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/examples/wordcount/run_wc.py
+++ b/examples/wordcount/run_wc.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/__init__.py
+++ b/pydoop/__init__.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/app/__init__.py
+++ b/pydoop/app/__init__.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/app/argparse_types.py
+++ b/pydoop/app/argparse_types.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/app/main.py
+++ b/pydoop/app/main.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/app/script.py
+++ b/pydoop/app/script.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/app/submit.py
+++ b/pydoop/app/submit.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/avrolib.py
+++ b/pydoop/avrolib.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/hadoop_utils.py
+++ b/pydoop/hadoop_utils.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/hadut.py
+++ b/pydoop/hadut.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/hdfs/__init__.py
+++ b/pydoop/hdfs/__init__.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/hdfs/common.py
+++ b/pydoop/hdfs/common.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/hdfs/core/__init__.py
+++ b/pydoop/hdfs/core/__init__.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/hdfs/core/api.py
+++ b/pydoop/hdfs/core/api.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/hdfs/core/bridged/__init__.py
+++ b/pydoop/hdfs/core/bridged/__init__.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/hdfs/core/bridged/common.py
+++ b/pydoop/hdfs/core/bridged/common.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/hdfs/core/bridged/hadoop.py
+++ b/pydoop/hdfs/core/bridged/hadoop.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/hdfs/core/impl.py
+++ b/pydoop/hdfs/core/impl.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/hdfs/file.py
+++ b/pydoop/hdfs/file.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/hdfs/fs.py
+++ b/pydoop/hdfs/fs.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/hdfs/path.py
+++ b/pydoop/hdfs/path.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/jc.py
+++ b/pydoop/jc.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/mapreduce/api.py
+++ b/pydoop/mapreduce/api.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/mapreduce/binary_streams.py
+++ b/pydoop/mapreduce/binary_streams.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/mapreduce/connections.py
+++ b/pydoop/mapreduce/connections.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/mapreduce/jwritable_utils.py
+++ b/pydoop/mapreduce/jwritable_utils.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/mapreduce/pipes.py
+++ b/pydoop/mapreduce/pipes.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/mapreduce/simulator.py
+++ b/pydoop/mapreduce/simulator.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/mapreduce/streams.py
+++ b/pydoop/mapreduce/streams.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/mapreduce/string_utils.py
+++ b/pydoop/mapreduce/string_utils.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/mapreduce/text_streams.py
+++ b/pydoop/mapreduce/text_streams.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/pipes.py
+++ b/pydoop/pipes.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/test_support.py
+++ b/pydoop/test_support.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/test_utils.py
+++ b/pydoop/test_utils.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/utils/__init__.py
+++ b/pydoop/utils/__init__.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/utils/bridge/factory.py
+++ b/pydoop/utils/bridge/factory.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/utils/bridge/jpype_loader.py
+++ b/pydoop/utils/bridge/jpype_loader.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/utils/bridge/pyjnius_loader.py
+++ b/pydoop/utils/bridge/pyjnius_loader.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/utils/conversion_tables.py
+++ b/pydoop/utils/conversion_tables.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/utils/jvm.py
+++ b/pydoop/utils/jvm.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/utils/misc.py
+++ b/pydoop/utils/misc.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/pydoop/utils/serialize.py
+++ b/pydoop/utils/serialize.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/src/native_core_hdfs/hdfs_file.cc
+++ b/src/native_core_hdfs/hdfs_file.cc
@@ -1,6 +1,6 @@
 /* BEGIN_COPYRIGHT
  *
- * Copyright 2009-2015 CRS4.
+ * Copyright 2009-2016 CRS4.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/src/native_core_hdfs/hdfs_file.h
+++ b/src/native_core_hdfs/hdfs_file.h
@@ -1,6 +1,6 @@
 /* BEGIN_COPYRIGHT
  *
- * Copyright 2009-2015 CRS4.
+ * Copyright 2009-2016 CRS4.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/src/native_core_hdfs/hdfs_fs.cc
+++ b/src/native_core_hdfs/hdfs_fs.cc
@@ -1,6 +1,6 @@
 /* BEGIN_COPYRIGHT
  *
- * Copyright 2009-2015 CRS4.
+ * Copyright 2009-2016 CRS4.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/src/native_core_hdfs/hdfs_fs.h
+++ b/src/native_core_hdfs/hdfs_fs.h
@@ -1,6 +1,6 @@
 /* BEGIN_COPYRIGHT
  *
- * Copyright 2009-2015 CRS4.
+ * Copyright 2009-2016 CRS4.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/src/native_core_hdfs/hdfs_module.cc
+++ b/src/native_core_hdfs/hdfs_module.cc
@@ -1,6 +1,6 @@
 /* BEGIN_COPYRIGHT
  *
- * Copyright 2009-2015 CRS4.
+ * Copyright 2009-2016 CRS4.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/src/serialize/protocol_codec.cc
+++ b/src/serialize/protocol_codec.cc
@@ -1,6 +1,6 @@
 /* BEGIN_COPYRIGHT
  *
- * Copyright 2009-2015 CRS4.
+ * Copyright 2009-2016 CRS4.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/src/v1/it/crs4/pydoop/NoSeparatorTextOutputFormat.java
+++ b/src/v1/it/crs4/pydoop/NoSeparatorTextOutputFormat.java
@@ -1,7 +1,7 @@
 
 // BEGIN_COPYRIGHT
 // 
-// Copyright 2009-2015 CRS4.
+// Copyright 2009-2016 CRS4.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy

--- a/src/v2/it/crs4/pydoop/NoSeparatorTextOutputFormat.java
+++ b/src/v2/it/crs4/pydoop/NoSeparatorTextOutputFormat.java
@@ -1,7 +1,7 @@
 
 // BEGIN_COPYRIGHT
 // 
-// Copyright 2009-2015 CRS4.
+// Copyright 2009-2016 CRS4.
 // 
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy

--- a/test/all_tests.py
+++ b/test/all_tests.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/app/all_tests.py
+++ b/test/app/all_tests.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/app/test_submit.py
+++ b/test/app/test_submit.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/avro/all_tests.py
+++ b/test/avro/all_tests.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/avro/test_context.py
+++ b/test/avro/test_context.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/avro/test_io.py
+++ b/test/avro/test_io.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/backward_compatibility/all_tests.py
+++ b/test/backward_compatibility/all_tests.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/backward_compatibility/all_tests_pipes.py
+++ b/test/backward_compatibility/all_tests_pipes.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/backward_compatibility/test_jobconf.py
+++ b/test/backward_compatibility/test_jobconf.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/backward_compatibility/test_protocol.py
+++ b/test/backward_compatibility/test_protocol.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/backward_compatibility/test_string_lifetime.py
+++ b/test/backward_compatibility/test_string_lifetime.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/backward_compatibility/test_task_context.py
+++ b/test/backward_compatibility/test_task_context.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/backward_compatibility/test_utils.py
+++ b/test/backward_compatibility/test_utils.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/backward_compatibility/try_hdfs.py
+++ b/test/backward_compatibility/try_hdfs.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/common/all_tests.py
+++ b/test/common/all_tests.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/common/test_hadut.py
+++ b/test/common/test_hadut.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/common/test_pydoop.py
+++ b/test/common/test_pydoop.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/hdfs/all_tests.py
+++ b/test/hdfs/all_tests.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/hdfs/test_hdfs.py
+++ b/test/hdfs/test_hdfs.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/hdfs/test_hdfs_fs.py
+++ b/test/hdfs/test_hdfs_fs.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/hdfs/test_local_fs.py
+++ b/test/hdfs/test_local_fs.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/hdfs/test_path.py
+++ b/test/hdfs/test_path.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/mapreduce/all_tests.py
+++ b/test/mapreduce/all_tests.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/mapreduce/test_binary_streams.py
+++ b/test/mapreduce/test_binary_streams.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/mapreduce/test_framework.py
+++ b/test/mapreduce/test_framework.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/mapreduce/test_streams.py
+++ b/test/mapreduce/test_streams.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/mapreduce/test_support.py
+++ b/test/mapreduce/test_support.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/mapreduce/test_support_old_api.py
+++ b/test/mapreduce/test_support_old_api.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/mapreduce/test_text_stream.py
+++ b/test/mapreduce/test_text_stream.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/mapreduce/test_utils.py
+++ b/test/mapreduce/test_utils.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/mapreduce/try_network_simulator.py
+++ b/test/mapreduce/try_network_simulator.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/mapreduce/utils.py
+++ b/test/mapreduce/utils.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/serialize/all_tests.py
+++ b/test/serialize/all_tests.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/serialize/hadoop_serialize.java
+++ b/test/serialize/hadoop_serialize.java
@@ -1,6 +1,6 @@
 /* BEGIN_COPYRIGHT
  *
- * Copyright 2009-2015 CRS4.
+ * Copyright 2009-2016 CRS4.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/test/serialize/test_serialize.py
+++ b/test/serialize/test_serialize.py
@@ -3,7 +3,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/timings/binary_build.py
+++ b/test/timings/binary_build.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/timings/dummy.cpp
+++ b/test/timings/dummy.cpp
@@ -1,6 +1,6 @@
 /* BEGIN_COPYRIGHT
  *
- * Copyright 2009-2015 CRS4.
+ * Copyright 2009-2016 CRS4.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/test/timings/setup.py
+++ b/test/timings/setup.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/timings/test_performances.py
+++ b/test/timings/test_performances.py
@@ -2,7 +2,7 @@
 
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/timings/timer.py
+++ b/test/timings/timer.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/timings/try_binary.py
+++ b/test/timings/try_binary.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy

--- a/test/timings/try_jpy.py
+++ b/test/timings/try_jpy.py
@@ -1,6 +1,6 @@
 # BEGIN_COPYRIGHT
 #
-# Copyright 2009-2015 CRS4.
+# Copyright 2009-2016 CRS4.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy


### PR DESCRIPTION
Bumps copyright end year across the whole project and adds the script used to do that to `dev_tools`. Note that this PR is for the release branch.