### PR TITLE
Py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ before_install:
 #- if [[ $HDFS_BACKEND == "jpype-bridged" ]]; then wget http://sourceforge.net/projects/jpype/files/JPype/0.5.4/JPype-0.5.4.2.zip; unzip JPype-0.5.4.2.zip; cd JPype-0.5.4.2; $VIRTUAL_ENV/bin/python setup.py install; cd ../; fi
 # JPype-0.6.1 @ originell/jpype
 - if [[ $HDFS_BACKEND == "jpype-bridged"  ]]; then git clone https://github.com/originell/jpype.git /tmp/jpype; pushd /tmp/jpype; ${VIRTUAL_ENV}/bin/python setup.py install; popd; fi
-- ${VIRTUAL_ENV}/bin/pip install avro flake8
+- ${VIRTUAL_ENV}/bin/pip install avro flake8 future
 - ssh-keygen -t dsa -P '' -f ~/.ssh/id_dsa
 - cat ~/.ssh/id_dsa.pub >> ~/.ssh/authorized_keys
 - echo NoHostAuthenticationForLocalhost=yes >> ~/.ssh/config

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 TEMPDIR := $(shell mktemp -u)
 GIT_COMMIT_FN = .git_commit
 WHEEL_DIR=./dist
-PY_V := $(shell python -c 'import sys; print("%d.%d" % sys.version_info[:2])')
+PYTHON=python
+PY_V := $(shell ${PYTHON} -c 'import sys; print("%d.%d" % sys.version_info[:2])')
 
 TARGETS=all build wheel install install_user install_wheel install_wheel_user\
         docs docs_py docs_view \
@@ -13,16 +14,16 @@ all:
 	@echo "Try one of: ${TARGETS}"
 
 install_user: build
-	python setup.py install --user
+	${PYTHON} setup.py install --user
 
 install: build
-	python setup.py install
+	${PYTHON} setup.py install
 
 build:
-	python setup.py build
+	${PYTHON} setup.py build
 
 wheel:
-	python setup.py bdist_wheel --dist-dir=${WHEEL_DIR}
+	${PYTHON} setup.py bdist_wheel --dist-dir=${WHEEL_DIR}
 
 install_wheel: wheel
 	pip install --use-wheel --no-index --pre --find-links=${WHEEL_DIR} pydoop
@@ -63,12 +64,12 @@ dist: docs
 	git rev-parse HEAD >$(TEMPDIR)/$(GIT_COMMIT_FN)
 	rm -rf $(TEMPDIR)/docs/*
 	mv docs/_build/html $(TEMPDIR)/docs/
-	cd $(TEMPDIR) && python setup.py sdist
+	cd $(TEMPDIR) && ${PYTHON} setup.py sdist
 	mv -i $(TEMPDIR)/dist/pydoop-*.tar.gz .
 	rm -rf $(TEMPDIR)
 
 clean:
-	python setup.py clean --all
+	${PYTHON} setup.py clean --all
 	rm -rf pydoop.egg-
 	rm -f docs/_static/logo.png docs/_static/favicon.ico
 	make -C docs clean

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TEMPDIR := $(shell mktemp -u)
 GIT_COMMIT_FN = .git_commit
 WHEEL_DIR=./dist
-PY_V := $(shell python -c 'import sys; print "%d.%d" % sys.version_info[:2]')
+PY_V := $(shell python -c 'import sys; print("%d.%d" % sys.version_info[:2])')
 
 TARGETS=all build wheel install install_user install_wheel install_wheel_user\
         docs docs_py docs_view \

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,3 @@
+clean:
+	echo "Cleaning in examples has not been implemented yet"
+

--- a/examples/run_all
+++ b/examples/run_all
@@ -9,7 +9,7 @@ examples=(
 #    self_contained
     sequence_file
     wordcount
-    simulator
+#    simulator
 )
 
 some_failed=0

--- a/examples/run_all
+++ b/examples/run_all
@@ -6,7 +6,7 @@ examples=(
     input_format
     pydoop_script
     pydoop_submit
-    self_contained
+#    self_contained
     sequence_file
     wordcount
     simulator

--- a/examples/self_contained/Makefile
+++ b/examples/self_contained/Makefile
@@ -80,7 +80,7 @@ ${ARCHIVES}:
 	cd ../..; ${PYTHON} setup.py bdist_wheel --dist-dir=./dist; cd -
 	${PIP} wheel --wheel-dir=${WHEEL_DIR} setuptools==$(SETUPTOOLS_VERSION)
 	${PIP} install --use-wheel --pre --find-links=${WHEEL_DIR} -t ./pkgs  pydoop
-	rm ./pkgs/*dist-info
+	rm -rf ./pkgs/*dist-info
 	cd pkgs; for x in *; do cd ${x}; tar cfz ../../${x}.tgz . ; cd ..; done; cd ..
 	rm -rf pkgs
 

--- a/examples/self_contained/Makefile
+++ b/examples/self_contained/Makefile
@@ -21,6 +21,10 @@ pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
 WHEEL_DIR=../../dist
 SUBMIT_CMD=pydoop submit
 SETUPTOOLS_VERSION := 3.3
+PYTHON=python2.7
+PIP=pip2.7
+ARCHIVES=pydoop.tgz future.tgz
+ARCHIVES_UPLOAD_FLAG=$(foreach tgz,${ARCHIVES},--upload-archive-to-cache ${tgz})
 
 HDFS=$(if $(call pathsearch,hdfs),$(call pathsearch,hdfs) dfs ,\
        $(if $(call pathsearch,hadoop),$(call pathsearch,hadoop) fs ,\
@@ -39,7 +43,7 @@ OUTPUT=${PROGNAME}_output
 run: check_result
 
 check_result: submit
-	python check_results.py /user/${USER}/${INPUT} /user/${USER}/${OUTPUT} 
+	${PYTHON} check_results.py /user/${USER}/${INPUT} /user/${USER}/${OUTPUT} 
 
 setup_io:
 	-${HDFS} -rmr /user/${USER}/${INPUT}
@@ -51,7 +55,7 @@ setup_io:
 
 submit: vowelcount.zip pydoop.tgz setup_io
 	${SUBMIT_CMD} --python-zip vowelcount.zip \
-                --upload-archive-to-cache pydoop.tgz\
+                ${ARCHIVES_UPLOAD_FLAG}\
                 --log-level ${LOGLEVEL} --job-name ${JOBNAME}\
                 --no-override-home --no-override-env\
                 vowelcount.mr.main --entry-point main \
@@ -59,7 +63,7 @@ submit: vowelcount.zip pydoop.tgz setup_io
 
 submit2: vowelcount.tgz pydoop.tgz setup_io
 	${SUBMIT_CMD} --upload-archive-to-cache vowelcount.tgz\
-                --upload-archive-to-cache pydoop.tgz\
+                ${ARCHIVES_UPLOAD_FLAG}\
                 --module vowelcount.mr.main --entry-point main\
                 --log-level ${LOGLEVEL} --job-name ${JOBNAME}\
                 --no-override-home --no-override-env\
@@ -72,12 +76,15 @@ vowelcount.tgz:
 	cd vowelcount; tar cfz ../vowelcount.tgz . ; cd -
 
 # don't use $(MAKE) -C ../.. wheel, top Makefile is only present in git repo
-pydoop.tgz:
-	cd ../..; python setup.py bdist_wheel --dist-dir=./dist; cd -
-	pip wheel --wheel-dir=${WHEEL_DIR} setuptools==$(SETUPTOOLS_VERSION)
-	pip install --use-wheel --no-index --pre --find-links=${WHEEL_DIR} -t .  pydoop
-	cd pydoop; tar cfz ../pydoop.tgz . ; cd -
-	rm -rf pydoop pydoop-*
+${ARCHIVES}:
+	cd ../..; ${PYTHON} setup.py bdist_wheel --dist-dir=./dist; cd -
+	${PIP} wheel --wheel-dir=${WHEEL_DIR} setuptools==$(SETUPTOOLS_VERSION)
+	${PIP} install --use-wheel --pre --find-links=${WHEEL_DIR} -t ./pkgs  pydoop
+	rm ./pkgs/*dist-info
+	cd pkgs; for x in *; do cd ${x}; tar cfz ../../${x}.tgz . ; cd ..; done; cd ..
+	rm -rf pkgs
 
 clean:
-	rm -rf pydoop.tgz vowelcount.zip
+	rm -rf ${ARCHIVES} vowelcount.zip
+
+

--- a/examples/self_contained/Makefile
+++ b/examples/self_contained/Makefile
@@ -21,9 +21,10 @@ pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
 WHEEL_DIR=../../dist
 SUBMIT_CMD=pydoop submit
 SETUPTOOLS_VERSION := 3.3
-PYTHON=python2.7
-PIP=pip2.7
-ARCHIVES=pydoop.tgz future.tgz
+PYTHON=python
+PIP=pip
+PACKAGES=pydoop
+ARCHIVES=$(foreach pkg,${PACKAGES},${pkg}.tgz)
 ARCHIVES_UPLOAD_FLAG=$(foreach tgz,${ARCHIVES},--upload-archive-to-cache ${tgz})
 
 HDFS=$(if $(call pathsearch,hdfs),$(call pathsearch,hdfs) dfs ,\
@@ -80,8 +81,7 @@ ${ARCHIVES}:
 	cd ../..; ${PYTHON} setup.py bdist_wheel --dist-dir=./dist; cd -
 	${PIP} wheel --wheel-dir=${WHEEL_DIR} setuptools==$(SETUPTOOLS_VERSION)
 	${PIP} install --use-wheel --pre --find-links=${WHEEL_DIR} -t ./pkgs  pydoop
-	rm -rf ./pkgs/*dist-info
-	cd pkgs; for x in *; do cd ${x}; tar cfz ../../${x}.tgz . ; cd ..; done; cd ..
+	cd pkgs; for x in ${PACKAGES}; do cd ${x}; tar cfz ../../${x}.tgz . ; cd ..; done; cd ..
 	rm -rf pkgs
 
 clean:

--- a/pydoop/__init__.py
+++ b/pydoop/__init__.py
@@ -26,10 +26,13 @@ Pydoop: a Python MapReduce and HDFS API for Hadoop
 Pydoop is a Python interface to Hadoop that allows you to write
 MapReduce applications and interact with HDFS in pure Python.
 """
-
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
+ 
 import os
 import errno
-import ConfigParser
+import configparser
 from importlib import import_module
 import pydoop.hadoop_utils as hu
 
@@ -162,6 +165,12 @@ class AddSectionWrapper(object):
         self.f = f
         self.sechead = '[dummy]' + os.linesep
 
+    def __iter__(self):
+        line = self.readline()
+        while line:
+            yield line
+            line = self.readline()
+
     def readline(self):
         if self.sechead:
             try:
@@ -171,12 +180,13 @@ class AddSectionWrapper(object):
         else:
             return self.f.readline()
 
-
 def read_properties(fname):
-    parser = ConfigParser.SafeConfigParser()
+    parser = configparser.SafeConfigParser()
     parser.optionxform = str  # preserve key case
     try:
-        with open(fname) as f:
+        with open(fname, 'rt') as f:
+            # use readfp instead of read_file because of p2.7
+            # compatibility
             parser.readfp(AddSectionWrapper(f))
     except IOError as e:
         if e.errno != errno.ENOENT:

--- a/pydoop/__init__.py
+++ b/pydoop/__init__.py
@@ -29,7 +29,7 @@ MapReduce applications and interact with HDFS in pure Python.
 from future import standard_library
 standard_library.install_aliases()
 from builtins import object
- 
+
 import os
 import errno
 import configparser
@@ -179,6 +179,7 @@ class AddSectionWrapper(object):
                 self.sechead = None
         else:
             return self.f.readline()
+
 
 def read_properties(fname):
     parser = configparser.SafeConfigParser()

--- a/pydoop/app/script.py
+++ b/pydoop/app/script.py
@@ -27,6 +27,7 @@ a map-reduce program using functions contained in a user provided
 python module.
 
 """
+from builtins import object
 
 import os
 import warnings

--- a/pydoop/app/submit.py
+++ b/pydoop/app/submit.py
@@ -19,6 +19,11 @@
 """
 An interface to simplify pydoop jobs submission.
 """
+from builtins import map
+from builtins import str
+from builtins import oct
+from builtins import range
+from builtins import object
 
 import os
 import sys
@@ -192,12 +197,12 @@ class PydoopSubmitter(object):
             host_port = "hdfs://%s:%s/" % (host, port)
         path_pieces = path.strip('/').split(os.path.sep)
         fs = hdfs.hdfs(host, port)
-        for i in xrange(0, len(path_pieces)):
+        for i in range(0, len(path_pieces)):
             part = os.path.join(
                 host_port, os.path.sep.join(path_pieces[0: i + 1])
             )
             permissions = fs.get_path_info(part)['permissions']
-            if permissions & 0111 != 0111:
+            if permissions & 0o111 != 0o111:
                 self.logger.warning(
                     ("remote module %s may not be readable by the task "
                      "tracker when initializing the distributed cache.  "
@@ -222,7 +227,7 @@ class PydoopSubmitter(object):
             env['PYTHONPATH'] = "${PYTHONPATH}"
 
         # set user-requested env variables
-        for var, value in self.requested_env.iteritems():
+        for var, value in self.requested_env.items():
             env[var] = value
 
         executable = self.args.python_program
@@ -248,7 +253,7 @@ class PydoopSubmitter(object):
         ):
             lines.append('export HOME="%s"' % os.environ['HOME'])
         # set environment variables
-        for var, value in env.iteritems():
+        for var, value in env.items():
             if value:
                 self.logger.debug("Setting env variable %s=%s", var, value)
                 lines.append('export %s="%s"' % (var, value))
@@ -390,7 +395,7 @@ class PydoopSubmitter(object):
             ctable = (conv_tables.mrv1_to_mrv2
                       if self._use_mrv2 else conv_tables.mrv2_to_mrv1)
             props = [
-                (ctable.get(k, k), v) for (k, v) in self.properties.iteritems()
+                (ctable.get(k, k), v) for (k, v) in self.properties.items()
             ]
             self.properties = dict(props)
             self.logger.debug("properties after projection: %r",
@@ -408,8 +413,8 @@ class PydoopSubmitter(object):
 
     def fake_run_class(self, *args, **kwargs):
         kwargs['logger'].info("Fake run class")
-        repr_list = map(repr, args)
-        repr_list.extend('%s=%r' % (k, v) for k, v in kwargs.iteritems())
+        repr_list = list(map(repr, args))
+        repr_list.extend('%s=%r' % (k, v) for k, v in kwargs.items())
         sys.stdout.write("hadut.run_class(%s)\n" % ', '.join(repr_list))
 
 

--- a/pydoop/avrolib.py
+++ b/pydoop/avrolib.py
@@ -19,11 +19,17 @@
 """
 Avro tools.
 """
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import next
+from past.utils import old_div
+from builtins import object
 # DEV NOTE: since Avro is not a requirement, do *not* import this
 # module anywhere in the main code (importing it in the Avro examples
 # is OK, ofc).
 
-from cStringIO import StringIO
+from io import StringIO
 
 import avro.schema
 from avro.datafile import DataFileReader, DataFileWriter
@@ -157,7 +163,7 @@ class AvroContext(pp.TaskContext):
         out_kv = {'K': key, 'V': value}
         jc = self.job_conf
         if AVRO_OUTPUT in jc and (self.is_reducer() or self.__is_map_only()):
-            for mode, record in out_kv.iteritems():
+            for mode, record in out_kv.items():
                 serializer = self.__serializers.get(mode)
                 if serializer is not None:
                     with self.timer.time_block('avro serialization'):
@@ -216,11 +222,11 @@ class AvroReader(RecordReader):
                                              DatumReader())
         self.reader.align_after(isplit.offset)
 
-    def next(self):
+    def __next__(self):
         pos = self.reader.reader.tell()
         if pos > self.region_end and self.reader.block_count == 0:
             raise StopIteration
-        record = self.reader.next()
+        record = next(self.reader)
         return pos, record
 
     def get_progress(self):
@@ -228,8 +234,8 @@ class AvroReader(RecordReader):
         Give a rough estimate of the progress done.
         """
         pos = self.reader.reader.tell()
-        return min((pos - self.region_start) /
-                   float(self.region_end - self.region_start),
+        return min(old_div((pos - self.region_start),
+                   float(self.region_end - self.region_start)),
                    1.0)
 
 

--- a/pydoop/hadoop_utils.py
+++ b/pydoop/hadoop_utils.py
@@ -33,6 +33,8 @@ import platform
 import subprocess as sp
 import xml.dom.minidom as dom
 from xml.parsers.expat import ExpatError
+from builtins import map
+from builtins import object
 
 try:
     from pydoop.config import DEFAULT_HADOOP_HOME
@@ -489,8 +491,9 @@ class PathFinder(object):
                         # why pop HADOOP_HOME?
                         env.pop("HADOOP_PREFIX", None)
                         env.pop("HADOOP_HOME", None)
-                        p = sp.Popen([hadoop, "version"], stdout=sp.PIPE,
-                                     stderr=sp.PIPE, env=env)
+                        p = sp.Popen([hadoop, "version"],
+                                     stdout=sp.PIPE, stderr=sp.PIPE,
+                                     env=env, universal_newlines=True)
                         out, err = p.communicate()
                         if p.returncode:
                             raise RuntimeError(err or out)

--- a/pydoop/hadoop_utils.py
+++ b/pydoop/hadoop_utils.py
@@ -368,6 +368,12 @@ def parse_hadoop_conf_file(fn):
 
 
 def _hadoop_home_from_version_cmd():
+    def clean_jar_path(jarpath):
+        dirname = os.path.dirname(jarpath)
+        m = re.match(r'(.*)/share/hadoop/common', dirname)
+        if m:
+            return m.group(1)
+        return dirname
     def get_hh_from_version_output(output):
         """
         the ``hadoop version`` command prints out some information.  The
@@ -379,7 +385,7 @@ def _hadoop_home_from_version_cmd():
         last_line = output.splitlines()[-1]
         m = re.match(r'This command was run using (.*\.jar)', last_line)
         if m:
-            home = os.path.dirname(m.group(1))
+            home = clean_jar_path(m.group(1))
             return home
         return None
 
@@ -393,7 +399,8 @@ def _hadoop_home_from_version_cmd():
 
     if hadoop_exec:
         try:
-            output = sp.check_output([hadoop_exec, 'version'])
+            output = sp.check_output([hadoop_exec, 'version'],
+                                     universal_newlines=True)
             return get_hh_from_version_output(output)
         except sp.CalledProcessError:
             pass

--- a/pydoop/hadut.py
+++ b/pydoop/hadut.py
@@ -20,6 +20,9 @@
 The hadut module provides access to some functionalities available
 via the Hadoop shell.
 """
+from builtins import map
+from past.builtins import basestring
+from builtins import object
 
 import os
 import shlex
@@ -73,7 +76,7 @@ def _merge_csv_args(args):
             merge_map.setdefault(k, []).append(v.strip())
             del args[i: i + 2]
         i -= 1
-    for k, vlist in merge_map.iteritems():
+    for k, vlist in merge_map.items():
         args.extend([k, ",".join(vlist)])
 
 # FIXME: the above functions share a lot of code
@@ -81,7 +84,7 @@ def _merge_csv_args(args):
 
 
 def _construct_property_args(prop_dict):
-    return sum((['-D', '%s=%s' % p] for p in prop_dict.iteritems()), [])
+    return sum((['-D', '%s=%s' % p] for p in prop_dict.items()), [])
 
 
 # 'a:b:c' OR ['a', 'b', 'c'] OR ['a:b', 'c'] --> {'a', 'b', 'c'}
@@ -151,7 +154,7 @@ def run_cmd(cmd, args=None, properties=None, hadoop_home=None,
         _merge_csv_args(args)
         gargs = _pop_generic_args(args)
         for seq in gargs, args:
-            _args.extend(map(str, seq))
+            _args.extend(list(map(str, seq)))
     logger.debug('final args: %r' % (_args,))
     if keep_streams:
         p = subprocess.Popen(

--- a/pydoop/hdfs/__init__.py
+++ b/pydoop/hdfs/__init__.py
@@ -157,7 +157,7 @@ def load(hdfs_path, **kwargs):
             else:
                 break
     fi.fs.close()
-    return "".join(data)
+    return b"".join(data)
 
 
 def _cp_file(src_fs, src_path, dest_fs, dest_path, **kwargs):

--- a/pydoop/hdfs/__init__.py
+++ b/pydoop/hdfs/__init__.py
@@ -47,6 +47,7 @@ appropriate for most applications.  If your needs are different, you
 can set the environment variable externally and it will override the
 above setting.
 """
+from builtins import next
 
 __all__ = [
     'path',

--- a/pydoop/hdfs/__init__.py
+++ b/pydoop/hdfs/__init__.py
@@ -293,7 +293,7 @@ def lsl(hdfs_path, user=None, recursive=False):
         dir_list = fs.list_directory(path_)
     else:
         treewalk = fs.walk(path_)
-        top = treewalk.next()
+        top = next(treewalk)
         if top['kind'] == 'directory':
             dir_list = list(treewalk)
         else:

--- a/pydoop/hdfs/common.py
+++ b/pydoop/hdfs/common.py
@@ -27,7 +27,7 @@ import grp
 import sys
 
 __is_py3 = sys.version_info >= (3, 0)
-    
+
 
 BUFSIZE = 16384
 DEFAULT_PORT = 8020  # org/apache/hadoop/hdfs/server/namenode/NameNode.java

--- a/pydoop/hdfs/common.py
+++ b/pydoop/hdfs/common.py
@@ -19,11 +19,15 @@
 """
 Common hdfs utilities.
 """
+from builtins import str
 
 import getpass
 import pwd
 import grp
+import sys
 
+__is_py3 = sys.version_info >= (3, 0)
+    
 
 BUFSIZE = 16384
 DEFAULT_PORT = 8020  # org/apache/hadoop/hdfs/server/namenode/NameNode.java
@@ -38,24 +42,32 @@ TEXT_ENCODING = 'utf-8'
 
 
 def encode_path(path):
+    if __is_py3:
+        return path
     if isinstance(path, str):
         path = path.encode('utf-8')
     return path
 
 
 def decode_path(path):
+    if __is_py3:
+        return path
     if isinstance(path, str):
         path = path.decode('utf-8')
     return path
 
 
 def encode_host(host):
+    if __is_py3:
+        return host
     if isinstance(host, str):
         host = host.encode('idna')
     return host
 
 
 def decode_host(host):
+    if __is_py3:
+        return host
     if isinstance(host, str):
         host = host.decode('idna')
     return host

--- a/pydoop/hdfs/common.py
+++ b/pydoop/hdfs/common.py
@@ -38,7 +38,7 @@ TEXT_ENCODING = 'utf-8'
 
 
 def encode_path(path):
-    if isinstance(path, unicode):
+    if isinstance(path, str):
         path = path.encode('utf-8')
     return path
 
@@ -50,7 +50,7 @@ def decode_path(path):
 
 
 def encode_host(host):
-    if isinstance(host, unicode):
+    if isinstance(host, str):
         host = host.encode('idna')
     return host
 

--- a/pydoop/hdfs/core/api.py
+++ b/pydoop/hdfs/core/api.py
@@ -19,18 +19,18 @@
 """
 Abstract low-level HDFS interface.
 """
+from builtins import object
 
 from abc import ABCMeta, abstractmethod
 
 from pydoop.hdfs.common import BUFSIZE
+from future.utils import with_metaclass
 
 
-class CoreHdfsFs(object):
+class CoreHdfsFs(with_metaclass(ABCMeta, object)):
     """
     Abstract filesystem interface.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def close(self):
@@ -134,12 +134,10 @@ class CoreHdfsFs(object):
         pass
 
 
-class CoreHdfsFile(object):
+class CoreHdfsFile(with_metaclass(ABCMeta, object)):
     """
     Abstract file object interface.
     """
-
-    __metaclass__ = ABCMeta
 
     @property
     def mode(self):

--- a/pydoop/hdfs/core/bridged/hadoop.py
+++ b/pydoop/hdfs/core/bridged/hadoop.py
@@ -21,6 +21,11 @@ import ctypes
 import logging
 logging.basicConfig(level=logging.INFO)
 
+from builtins import chr
+from builtins import str
+from builtins import range
+from builtins import object
+
 from pydoop.hdfs.core.api import CoreHdfsFs as CoreFsApi
 from pydoop.hdfs.core.api import CoreHdfsFile as CoreFileApi
 
@@ -38,7 +43,7 @@ def _unsigned_bytes(jbuf, off=0, length=None):
     stop = off + length
     if stop > len(jbuf):
         raise IndexError('buffer index out of range')
-    return ''.join(chr(jbuf[_] & 0xff) for _ in xrange(off, stop))
+    return ''.join(chr(jbuf[_] & 0xff) for _ in range(off, stop))
 
 
 class JavaClassName(object):
@@ -335,7 +340,7 @@ class CoreHdfsFile(CoreFileApi):
             raise IOError
         try:
             self._stream.close()
-        except Exception, e:
+        except Exception as e:
             raise IOError(e.message)
 
     def write_chunk(self, chunk):
@@ -355,7 +360,7 @@ class CoreHdfsFile(CoreFileApi):
             elif isinstance(data, ctypes.Array):
                 to_write = data[:]
             else:
-                if isinstance(data, unicode):
+                if isinstance(data, str):
                     data = data.encode(TEXT_ENCODING)
                 to_write = self._jbytearray(data)
             self._stream.write(to_write)
@@ -365,12 +370,12 @@ class CoreHdfsFile(CoreFileApi):
     def tell(self):
         if not self._stream:
             raise IOError
-        return long(self._stream.getPos())
+        return int(self._stream.getPos())
 
     def seek(self, position):
         if not self._stream or self._stream_type != self.INPUT:
             raise IOError
-        self._stream.seek(long(position))
+        self._stream.seek(int(position))
 
     def read(self, length=-1):
         if not self._stream or self._stream_type != self.INPUT:
@@ -406,7 +411,7 @@ class CoreHdfsFile(CoreFileApi):
         jbyte_buffer_class = wrap_class(JavaClassName.ByteBuffer)
         bb = jbyte_buffer_class.allocate(length)
         buf = bb.array()
-        read = self._stream.read(long(position), buf, 0, length)
+        read = self._stream.read(int(position), buf, 0, length)
         return _unsigned_bytes(buf, length=read)
 
     def pread_chunk(self, position, chunk):
@@ -416,7 +421,7 @@ class CoreHdfsFile(CoreFileApi):
         jbyte_buffer_class = wrap_class(JavaClassName.ByteBuffer)
         bb = jbyte_buffer_class.allocate(length)
         buf = bb.array()
-        read = self._stream.read(long(position), buf, 0, length)
+        read = self._stream.read(int(position), buf, 0, length)
         chunk[:read] = _unsigned_bytes(buf, length=read)
         return read
 

--- a/pydoop/hdfs/file.py
+++ b/pydoop/hdfs/file.py
@@ -378,7 +378,10 @@ class local_file(FileIO):
         elif not isinstance(data, (basestring, bytearray, bytes)):
             # access non string data through a buffer
             data = bytearray(data)
-        super().write(data)
+        try: # For some mysterious reason, it will raise a ValueError in py2.7
+            super().write(data)
+        except ValueError as e:
+            raise IOError(*e.args)
         return len(data)
 
     def available(self):

--- a/pydoop/hdfs/file.py
+++ b/pydoop/hdfs/file.py
@@ -22,6 +22,7 @@ pydoop.hdfs.file -- HDFS File Objects
 """
 
 from builtins import str
+from builtins import super
 from past.builtins import basestring
 from builtins import object
 from io import FileIO
@@ -325,14 +326,15 @@ class hdfs_file(object):
 
 
 class local_file(FileIO):
-
+    "Support class to handle local_file(s)"
     def __init__(self, fs, name, flags):
         if not flags.startswith("r"):
             local_file.__make_parents(fs, name)
-        super(local_file, self).__init__(name, flags)
+        name = os.path.abspath(name)
+        super().__init__(name, flags)
         self.__fs = fs
-        self.__name = os.path.abspath(super(local_file, self).name)
-        self.__size = os.fstat(super(local_file, self).fileno()).st_size
+        self.__name = name
+        self.__size = os.fstat(super().fileno()).st_size
         self.f = self
         self.chunk_size = 0
 
@@ -348,10 +350,6 @@ class local_file(FileIO):
     @property
     def fs(self):
         return self.__fs
-
-    @property
-    def name(self):
-        return self.__name
 
     @property
     def size(self):

--- a/pydoop/hdfs/file.py
+++ b/pydoop/hdfs/file.py
@@ -59,7 +59,7 @@ class hdfs_file(object):
     open an HDFS file, use :meth:`~.fs.hdfs.open_file`, or the
     top-level ``open`` function in the hdfs package.
     """
-    ENDL = os.linesep
+    ENDL = os.linesep.encode()
 
     def __init__(self, raw_hdfs_file, fs, name, flags,
                  chunk_size=common.BUFSIZE):
@@ -76,7 +76,7 @@ class hdfs_file(object):
 
     def __reset(self):
         self.buffer_list = []
-        self.chunk = ""
+        self.chunk = b""
         self.EOF = False
         self.p = 0
 
@@ -135,21 +135,32 @@ class hdfs_file(object):
             eol = self.chunk.find(self.ENDL, self.p)
         return eol if eol > -1 else len(self.chunk)
 
-    def readline(self):
+    def readline(self, encoding='utf-8', errors='strict'):
         """
         Read and return a line of text.
+
+        :type encoding: str
+        :param encoding: the encoding with which to decode the bytes.
+
+        :type errors: str
+
+        :param errors: The error handling scheme to use for the handling of
+        decoding errors. The default is 'strict' meaning that decoding errors
+        raise a UnicodeDecodeError. Other possible values are 'ignore' and
+        'replace' as well as any other name registered  with codecs.register_error
+        that can handle UnicodeDecodeErrors.
 
         :rtype: str
 
         :return: the next line of text in the file, including the
-          newline character
+        newline character
         """
         _complain_ifclosed(self.closed)
         eol = self.__read_chunks_until_nl()
-        line = "".join(self.buffer_list) + self.chunk[self.p: eol + 1]
+        line = b"".join(self.buffer_list) + self.chunk[self.p: eol + 1]
         self.buffer_list = []
         self.p = eol + 1
-        return line
+        return line.decode(encoding=encoding, errors=errors)
 
     def __next__(self):
         """
@@ -247,11 +258,11 @@ class hdfs_file(object):
             if length <= 0:
                 break
             c = self.f.read(min(self.chunk_size, length))
-            if c == "":
+            if c == b"":
                 break
             chunks.append(c)
             length -= len(c)
-        return "".join(chunks)
+        return b"".join(chunks)
 
     def read_chunk(self, chunk):
         r"""

--- a/pydoop/hdfs/file.py
+++ b/pydoop/hdfs/file.py
@@ -23,6 +23,7 @@ pydoop.hdfs.file -- HDFS File Objects
 
 from builtins import str
 from builtins import super
+from builtins import bytes
 from past.builtins import basestring
 from builtins import object
 from io import FileIO
@@ -359,10 +360,10 @@ class local_file(FileIO):
         _complain_ifclosed(self.closed)
         if isinstance(data, str):
             data = data.encode(common.TEXT_ENCODING)
-        elif not isinstance(data, (basestring, bytearray)):
+        elif not isinstance(data, (basestring, bytearray, bytes)):
             # access non string data through a buffer
-            data = str(buffer(data))
-        super(local_file, self).write(data)
+            data = bytearray(data)
+        super().write(data)
         return len(data)
 
     def available(self):
@@ -374,11 +375,11 @@ class local_file(FileIO):
             self.flush()
             os.fsync(self.fileno())
             self.__size = os.fstat(self.fileno()).st_size
-        super(local_file, self).close()
+        super().close()
 
     def seek(self, position, whence=os.SEEK_SET):
         position = _seek_with_boundary_checks(self, position, whence)
-        return super(local_file, self).seek(position)
+        return super().seek(position)
 
     def pread(self, position, length):
         _complain_ifclosed(self.closed)

--- a/pydoop/hdfs/file.py
+++ b/pydoop/hdfs/file.py
@@ -356,6 +356,10 @@ class local_file(FileIO):
     def size(self):
         return self.__size
 
+    @property
+    def mode(self):
+        return (super().mode).replace('b', '')
+
     def write(self, data):
         _complain_ifclosed(self.closed)
         if isinstance(data, str):

--- a/pydoop/hdfs/file.py
+++ b/pydoop/hdfs/file.py
@@ -411,3 +411,25 @@ class local_file(FileIO):
 
     def write_chunk(self, chunk):
         return self.write(chunk)
+    
+    def readline(self, encoding='utf-8', errors='strict'):
+        """
+        Read and return a line of text.
+
+        :type encoding: str
+        :param encoding: the encoding with which to decode the bytes.
+
+        :type errors: str
+
+        :param errors: The error handling scheme to use for the handling of
+        decoding errors. The default is 'strict' meaning that decoding errors
+        raise a UnicodeDecodeError. Other possible values are 'ignore' and
+        'replace' as well as any other name registered  with codecs.register_error
+        that can handle UnicodeDecodeErrors.
+
+        :rtype: str
+
+        :return: the next line of text in the file, including the
+        newline character
+        """
+        return super().readline().decode(encoding=encoding, errors=errors)

--- a/pydoop/hdfs/file.py
+++ b/pydoop/hdfs/file.py
@@ -21,6 +21,11 @@ pydoop.hdfs.file -- HDFS File Objects
 -------------------------------------
 """
 
+from builtins import str
+from past.builtins import basestring
+from builtins import object
+from io import FileIO
+
 import os
 
 from pydoop.hdfs import common
@@ -144,7 +149,7 @@ class hdfs_file(object):
         self.p = eol + 1
         return line
 
-    def next(self):
+    def __next__(self):
         """
         Return the next input line, or raise :class:`StopIteration`
         when EOF is hit.
@@ -319,7 +324,7 @@ class hdfs_file(object):
         return self.f.flush()
 
 
-class local_file(file):
+class local_file(FileIO):
 
     def __init__(self, fs, name, flags):
         if not flags.startswith("r"):
@@ -354,7 +359,7 @@ class local_file(file):
 
     def write(self, data):
         _complain_ifclosed(self.closed)
-        if isinstance(data, unicode):
+        if isinstance(data, str):
             data = data.encode(common.TEXT_ENCODING)
         elif not isinstance(data, (basestring, bytearray)):
             # access non string data through a buffer

--- a/pydoop/hdfs/file.py
+++ b/pydoop/hdfs/file.py
@@ -147,8 +147,8 @@ class hdfs_file(object):
         :param errors: The error handling scheme to use for the handling of
         decoding errors. The default is 'strict' meaning that decoding errors
         raise a UnicodeDecodeError. Other possible values are 'ignore' and
-        'replace' as well as any other name registered  with codecs.register_error
-        that can handle UnicodeDecodeErrors.
+        'replace' as well as any other name registered  with
+        codecs.register_error that can handle UnicodeDecodeErrors.
 
         :rtype: str
 
@@ -378,7 +378,7 @@ class local_file(FileIO):
         elif not isinstance(data, (basestring, bytearray, bytes)):
             # access non string data through a buffer
             data = bytearray(data)
-        try: # For some mysterious reason, it will raise a ValueError in py2.7
+        try:  # For some mysterious reason, it will raise a ValueError in py2.7
             super().write(data)
         except ValueError as e:
             raise IOError(*e.args)
@@ -425,7 +425,7 @@ class local_file(FileIO):
 
     def write_chunk(self, chunk):
         return self.write(chunk)
-    
+
     def readline(self, encoding='utf-8', errors='strict'):
         """
         Read and return a line of text.
@@ -438,8 +438,8 @@ class local_file(FileIO):
         :param errors: The error handling scheme to use for the handling of
         decoding errors. The default is 'strict' meaning that decoding errors
         raise a UnicodeDecodeError. Other possible values are 'ignore' and
-        'replace' as well as any other name registered  with codecs.register_error
-        that can handle UnicodeDecodeErrors.
+        'replace' as well as any other name registered
+        with codecs.register_error that can handle UnicodeDecodeErrors.
 
         :rtype: str
 

--- a/pydoop/hdfs/fs.py
+++ b/pydoop/hdfs/fs.py
@@ -20,10 +20,16 @@
 pydoop.hdfs.fs -- File System Handles
 -------------------------------------
 """
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from past.builtins import basestring
+from builtins import object
+from functools import reduce
 
 import os
 import socket
-import urlparse
+import urllib.parse
 import getpass
 import re
 import operator as ops
@@ -32,6 +38,7 @@ import pydoop
 from . import common
 from .file import hdfs_file, local_file
 from .core import core_hdfs_fs
+
 
 
 class _FSStatus(object):
@@ -62,7 +69,7 @@ def _get_ip(host, default=None):
 
 def _get_connection_info(host, port, user):
     fs = core_hdfs_fs(host, port, user)
-    res = urlparse.urlparse(fs.get_working_directory())
+    res = urllib.parse.urlparse(fs.get_working_directory())
     if res.scheme == "file":
         h, p, u = "", 0, getpass.getuser()
         fs.set_working_directory(os.getcwd())  # libhdfs "remembers" old cwd
@@ -211,7 +218,7 @@ class hdfs(object):
         self.__status.refcount -= 1
         if self.refcount == 0:
             self.fs.close()
-            for k, status in self._CACHE.items():  # yes, we want a copy
+            for k, status in list(self._CACHE.items()):  # yes, we want a copy
                 if status.refcount == 0:
                     del self._CACHE[k]
 

--- a/pydoop/hdfs/fs.py
+++ b/pydoop/hdfs/fs.py
@@ -40,7 +40,6 @@ from .file import hdfs_file, local_file
 from .core import core_hdfs_fs
 
 
-
 class _FSStatus(object):
 
     def __init__(self, fs, host, port, user, refcount=1):

--- a/pydoop/hdfs/path.py
+++ b/pydoop/hdfs/path.py
@@ -24,9 +24,8 @@ pydoop.hdfs.path -- Path Name Manipulations
 import os
 import re
 import time
-
+from past.builtins import long
 from . import common, fs as hdfs_fs
-
 
 curdir, pardir, sep = '.', '..', '/'  # pylint: disable=C0103
 
@@ -48,7 +47,7 @@ class StatResult(object):
     def __init__(self, path_info):
         self.st_mode = path_info['permissions']
         self.st_ino = 0
-        self.st_dev = 0L
+        self.st_dev = long(0)
         self.st_nlink = 1
         self.st_uid = path_info['owner']
         self.st_gid = path_info['group']

--- a/pydoop/hdfs/path.py
+++ b/pydoop/hdfs/path.py
@@ -20,11 +20,12 @@
 pydoop.hdfs.path -- Path Name Manipulations
 -------------------------------------------
 """
+from builtins import object
 
 import os
 import re
 import time
-from past.builtins import long
+from past.builtins import int
 from . import common, fs as hdfs_fs
 
 curdir, pardir, sep = '.', '..', '/'  # pylint: disable=C0103
@@ -47,7 +48,7 @@ class StatResult(object):
     def __init__(self, path_info):
         self.st_mode = path_info['permissions']
         self.st_ino = 0
-        self.st_dev = long(0)
+        self.st_dev = int(0)
         self.st_nlink = 1
         self.st_uid = path_info['owner']
         self.st_gid = path_info['group']

--- a/pydoop/hdfs/path.py
+++ b/pydoop/hdfs/path.py
@@ -25,7 +25,7 @@ from builtins import object
 import os
 import re
 import time
-from past.builtins import int
+from builtins import int
 from . import common, fs as hdfs_fs
 
 curdir, pardir, sep = '.', '..', '/'  # pylint: disable=C0103

--- a/pydoop/pipes.py
+++ b/pydoop/pipes.py
@@ -44,7 +44,7 @@ class RecordReader(new_RR):
     Breaks the data into key/value pairs for input to the :class:`Mapper`.
     """
     # we have to override next to document the different return value
-    def next(self):
+    def __next__(self):
         """
         Called by the framework to provide a key/value pair to the
         :class:`Mapper`.  Applications must override this.

--- a/pydoop/test_support.py
+++ b/pydoop/test_support.py
@@ -107,7 +107,7 @@ class LocalWordCount(object):
             self._wordcount_file(wc, self.input_path)
 
         if self.min_occurrence:
-            wc = dict(t for t in wc.items() if t[1] >= self.min_occurrence)
+            wc = dict(t for t in list(wc.items()) if t[1] >= self.min_occurrence)
         return wc
 
     def _wordcount_file(self, wc, fn, path=None):

--- a/pydoop/test_support.py
+++ b/pydoop/test_support.py
@@ -107,7 +107,8 @@ class LocalWordCount(object):
             self._wordcount_file(wc, self.input_path)
 
         if self.min_occurrence:
-            wc = dict(t for t in list(wc.items()) if t[1] >= self.min_occurrence)
+            wc = dict(t for t in list(wc.items())
+                      if t[1] >= self.min_occurrence)
         return wc
 
     def _wordcount_file(self, wc, fn, path=None):

--- a/pydoop/test_support.py
+++ b/pydoop/test_support.py
@@ -19,6 +19,8 @@
 """
 Miscellaneous utilities for testing.
 """
+from __future__ import print_function
+from builtins import object
 
 import re
 import sys
@@ -68,7 +70,7 @@ def parse_mr_output(output, vtype=str):
 
 def compare_counts(c1, c2):
     if len(c1) != len(c2):
-        print len(c1), len(c2)
+        print(len(c1), len(c2))
         return "number of keys differs"
     keys = sorted(c1)
     if sorted(c2) != keys:
@@ -105,7 +107,7 @@ class LocalWordCount(object):
             self._wordcount_file(wc, self.input_path)
 
         if self.min_occurrence:
-            wc = dict(t for t in wc.iteritems() if t[1] >= self.min_occurrence)
+            wc = dict(t for t in wc.items() if t[1] >= self.min_occurrence)
         return wc
 
     def _wordcount_file(self, wc, fn, path=None):

--- a/pydoop/test_utils.py
+++ b/pydoop/test_utils.py
@@ -19,6 +19,9 @@
 """
 Utilities for unit tests.
 """
+from builtins import chr
+from builtins import range
+from builtins import object
 
 import sys
 import os
@@ -130,9 +133,9 @@ def make_wd(fs, prefix="pydoop_test_"):
 def make_random_data(size=_RANDOM_DATA_SIZE, printable=True):
     randint = random.randint
     if printable:
-        return "".join([chr(randint(32, 126)) for _ in xrange(size)])
+        return bytes(randint(32, 126) for _ in range(size))
     else:
-        return "".join([chr(randint(0, 255)) for _ in xrange(size)])
+        return bytes(randint(0, 255) for _ in range(size))        
 
 
 def get_bytes_per_checksum():

--- a/pydoop/test_utils.py
+++ b/pydoop/test_utils.py
@@ -19,7 +19,6 @@
 """
 Utilities for unit tests.
 """
-from builtins import chr
 from builtins import range
 from builtins import object
 
@@ -135,7 +134,7 @@ def make_random_data(size=_RANDOM_DATA_SIZE, printable=True):
     if printable:
         return bytes(randint(32, 126) for _ in range(size))
     else:
-        return bytes(randint(0, 255) for _ in range(size))        
+        return bytes(randint(0, 255) for _ in range(size))
 
 
 def get_bytes_per_checksum():

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ Other relevant environment variables include::
   HADOOP_VERSION, e.g., 0.20.2-cdh3u4 (override Hadoop's version string).
 """
 
+from __future__ import print_function
+
+
 import time
 import os
 import glob
@@ -42,7 +45,7 @@ SETUPTOOLS_MIN_VER = '3.3'
 
 import setuptools
 from pkg_resources import parse_version  # included in setuptools
-print 'using setuptools version', setuptools.__version__
+print('using setuptools version', setuptools.__version__)
 if parse_version(setuptools.__version__) < parse_version(SETUPTOOLS_MIN_VER):
     raise RuntimeError(
         'setuptools minimum required version: %s' % SETUPTOOLS_MIN_VER
@@ -155,7 +158,8 @@ def get_git_commit():
             return f.read().strip()
     try:
         return subprocess.check_output(
-            ['git', 'rev-parse', 'HEAD']
+            ['git', 'rev-parse', 'HEAD'],
+            universal_newlines=True
         ).rstrip('\n')
     except subprocess.CalledProcessError:
         return None
@@ -368,7 +372,7 @@ class BuildPydoop(build):
         # may be called while executing other commands (e.g., clean)
         if HADOOP_VERSION_INFO.is_local():
             raise pydoop.LocalModeNotSupported()
-        print "hdfs core implementation: {0}".format(self.hdfs_core_impl)
+        print("hdfs core implementation: {0}".format(self.hdfs_core_impl))
         write_config(hdfs_core_impl=self.hdfs_core_impl)
         write_version()
         shutil.copyfile(PROP_FN, os.path.join("pydoop", PROP_BN))
@@ -422,6 +426,7 @@ setup(
     download_url="https://pypi.python.org/pypi/pydoop",
     install_requires=['setuptools>=%s' % SETUPTOOLS_MIN_VER],
     extras_require={
+        ':python_version=="2.7"': ['future'],
         'avro': ["avro>=1.7.4"],
     },
     packages=find_packages(exclude=['test', 'test.*']),
@@ -436,7 +441,8 @@ setup(
     license="Apache-2.0",
     keywords=["hadoop", "mapreduce"],
     classifiers=[
-        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
         "Topic :: Software Development :: Libraries :: Application Frameworks",

--- a/setup.py
+++ b/setup.py
@@ -376,8 +376,7 @@ class BuildPydoop(build):
         write_config(hdfs_core_impl=self.hdfs_core_impl)
         write_version()
         shutil.copyfile(PROP_FN, os.path.join("pydoop", PROP_BN))
-        # FIXME temporarily disabled 
-        # build_sercore_extension()
+        build_sercore_extension()
         if self.hdfs_core_impl == hdfsimpl.NATIVE:
             build_hdfscore_native_impl()
         build.run(self)

--- a/setup.py
+++ b/setup.py
@@ -376,7 +376,8 @@ class BuildPydoop(build):
         write_config(hdfs_core_impl=self.hdfs_core_impl)
         write_version()
         shutil.copyfile(PROP_FN, os.path.join("pydoop", PROP_BN))
-        build_sercore_extension()
+        # FIXME temporarily disabled 
+        # build_sercore_extension()
         if self.hdfs_core_impl == hdfsimpl.NATIVE:
             build_hdfscore_native_impl()
         build.run(self)

--- a/src/buf_macros.h
+++ b/src/buf_macros.h
@@ -1,0 +1,22 @@
+#ifndef PYDOOP_BUF_MACROS
+#define PYDOOP_BUF_MACROS 1
+
+
+#if PY_MAJOR_VERSION >= 3
+#define IS_PY3K 1
+#endif
+
+
+#if IS_PY3K
+#define _PyBuf_FromStringAndSize(s,nbytes) PyBytes_FromStringAndSize(s, nbytes)
+#define _PyBuf_AS_STRING(b) PyBytes_AS_STRING(b)
+#define _PyBuf_Resize(b, n) _PyBytes_Resize(b, n)
+#define _PyBuf_FromString(x) PyBytes_FromString(x)
+#else
+#define _PyBuf_FromStringAndSize(s,nbytes) PyString_FromStringAndSize(s, nbytes)
+#define _PyBuf_AS_STRING(b) PyString_AS_STRING(b)
+#define _PyBuf_Resize(b, n) _PyString_Resize(b, n)
+#define _PyBuf_FromString(x) PyString_FromString(x)
+#endif
+
+#endif /* PYDOOP_BUF_MACROS */

--- a/src/libhdfsV2/exception.c
+++ b/src/libhdfsV2/exception.c
@@ -89,7 +89,7 @@ static const struct ExceptionInfo gExceptionInfo[] = {
 void getExceptionInfo(const char *excName, int noPrintFlags,
                       int *excErrno, int *shouldPrint)
 {
-    int i;
+    unsigned int i;
 
     for (i = 0; i < EXCEPTION_INFO_LEN; i++) {
         if (strstr(gExceptionInfo[i].name, excName)) {
@@ -108,7 +108,7 @@ void getExceptionInfo(const char *excName, int noPrintFlags,
 int printExceptionAndFreeV(JNIEnv *env, jthrowable exc, int noPrintFlags,
         const char *fmt, va_list ap)
 {
-    int i, noPrint, excErrno;
+    unsigned int i, noPrint, excErrno;
     char *className = NULL;
     jstring jStr = NULL;
     jvalue jVal;

--- a/src/libhdfsV2/hdfs.c
+++ b/src/libhdfsV2/hdfs.c
@@ -1811,7 +1811,7 @@ char* hdfsGetWorkingDirectory(hdfsFS fs, char* buffer, size_t bufferSize)
 
     //Copy to user-provided buffer
     ret = snprintf(buffer, bufferSize, "%s", jPathChars);
-    if (ret >= bufferSize) {
+    if (ret >= (int) bufferSize) {
         ret = ENAMETOOLONG;
         goto done;
     }

--- a/src/libhdfsV2/jni_helper.c
+++ b/src/libhdfsV2/jni_helper.c
@@ -577,7 +577,7 @@ jthrowable fetchEnumInstance(JNIEnv *env, const char *className,
                 className, valueName);
     }
     if (snprintf(prettyClass, sizeof(prettyClass), "L%s;", className)
-          >= sizeof(prettyClass)) {
+        >= (int) sizeof(prettyClass)) {
         return newRuntimeError(env, "fetchEnum(%s, %s): class name too long.",
                 className, valueName);
     }

--- a/src/native_core_hdfs/hdfs_file.h
+++ b/src/native_core_hdfs/hdfs_file.h
@@ -21,6 +21,8 @@
 #define PYTHON_HDFS_FILE_TYPE
 
 #include <Python.h>
+
+
 #include <string>
 #include <map>
 #include <utility>  // std::pair support
@@ -31,6 +33,9 @@
 #include <hdfs.h>
 
 #include "structmember.h"
+#include "../buf_macros.h"
+
+
 
 
 typedef struct {

--- a/src/native_core_hdfs/hdfs_fs.cc
+++ b/src/native_core_hdfs/hdfs_fs.cc
@@ -51,7 +51,7 @@ PyObject* FsClass_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
 void FsClass_dealloc(FsInfo* self)
 {
-    self->ob_type->tp_free((PyObject*)self);
+    Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 
@@ -209,7 +209,7 @@ PyObject* FsClass_get_hosts(FsInfo* self, PyObject *args, PyObject *kwds) {
 
         for (int iBlockHost = 0; hosts[blockNumber][iBlockHost] != NULL; ++iBlockHost)
         {
-            PyObject* str = PyString_FromString(hosts[blockNumber][iBlockHost]);
+            PyObject* str = PyUnicode_FromString(hosts[blockNumber][iBlockHost]);
             if (!str) goto mem_error;
             if (PyList_Append(blockHosts, str) < 0) goto mem_error;
         }
@@ -491,14 +491,14 @@ static int setPathInfo(PyObject* dict, hdfsFileInfo* fileInfo) {
     // Prepare the values.  We'll check for all errors in the "set" loop below
     // The order of these values MUST match the order of the keys above
     values[i++] = PyUnicode_FromString(fileInfo->mName);
-    values[i++] = PyString_FromString(fileInfo->mKind == kObjectKindDirectory ? "directory" : "file");
-    values[i++] = PyString_FromString(fileInfo->mGroup);
-    values[i++] = PyInt_FromLong(fileInfo->mLastMod);
-    values[i++] = PyInt_FromLong(fileInfo->mLastAccess);
-    values[i++] = PyInt_FromSize_t(fileInfo->mReplication);
-    values[i++] = PyString_FromString(fileInfo->mOwner);
-    values[i++] = PyInt_FromSize_t(fileInfo->mPermissions);
-    values[i++] = PyInt_FromLong(fileInfo->mBlockSize);
+    values[i++] = PyUnicode_FromString(fileInfo->mKind == kObjectKindDirectory ? "directory" : "file");
+    values[i++] = PyUnicode_FromString(fileInfo->mGroup);
+    values[i++] = PyLong_FromLong(fileInfo->mLastMod);
+    values[i++] = PyLong_FromLong(fileInfo->mLastAccess);
+    values[i++] = PyLong_FromSize_t(fileInfo->mReplication);
+    values[i++] = PyUnicode_FromString(fileInfo->mOwner);
+    values[i++] = PyLong_FromSize_t(fileInfo->mPermissions);
+    values[i++] = PyLong_FromLong(fileInfo->mBlockSize);
     values[i++] = PyUnicode_FromString(fileInfo->mName);
     values[i++] = PyLong_FromLongLong(fileInfo->mSize);
 

--- a/src/native_core_hdfs/hdfs_fs.h
+++ b/src/native_core_hdfs/hdfs_fs.h
@@ -31,7 +31,7 @@
 #include <hdfs.h>
 
 #include "structmember.h"
-
+#include "../buf_macros.h"
 
 typedef struct {
     PyObject_HEAD

--- a/src/native_core_hdfs/hdfs_module.cc
+++ b/src/native_core_hdfs/hdfs_module.cc
@@ -211,7 +211,11 @@ static struct PyModuleDef module_def = {
 
 
 PyMODINIT_FUNC
+#if IS_PY3K
+PyInit_native_core_hdfs(void)
+#else
 initnative_core_hdfs(void)
+#endif
 {
   PyObject* m;
 

--- a/src/native_core_hdfs/hdfs_module.cc
+++ b/src/native_core_hdfs/hdfs_module.cc
@@ -27,7 +27,7 @@
 #include "hdfs_file.h"
 #include <jni.h>
 
-static char* module__name__ = "native_hdfs";
+static char* module__name__ = "native_core_hdfs";
 static char* module__doc__ = "native_hdfs_core implementation";
 
 /* FsType */
@@ -210,27 +210,18 @@ static struct PyModuleDef module_def = {
 #endif
 
 
-PyMODINIT_FUNC
 #if IS_PY3K
+
+PyMODINIT_FUNC
 PyInit_native_core_hdfs(void)
-#else
-initnative_core_hdfs(void)
-#endif
 {
   PyObject* m;
 
   if (PyType_Ready(&FsType) < 0)
     return NULL;
-
   if (PyType_Ready(&FileType) < 0)
     return NULL;
-#if IS_PY3K
   m = PyModule_Create(&module_def);
-#else
-  m = Py_InitModule3(module__name__, module_methods,
-                     module__doc__);
-#endif
-
   if (m == NULL)
     return NULL;
 
@@ -242,4 +233,26 @@ initnative_core_hdfs(void)
   return m;
 }
 
+#else
+
+PyMODINIT_FUNC
+initnative_core_hdfs(void)
+{
+  PyObject* m;
+
+  if (PyType_Ready(&FsType) < 0)
+    return;
+  if (PyType_Ready(&FileType) < 0)
+    return;
+  m = Py_InitModule3(module__name__, module_methods,
+                     module__doc__);
+  if (m == NULL)
+    return;
+
+  Py_INCREF(&FsType);
+  Py_INCREF(&FileType);
+  PyModule_AddObject(m, "CoreHdfsFs", (PyObject *)&FsType);
+  PyModule_AddObject(m, "CoreHdfsFile", (PyObject *)&FileType);
+}
+#endif
 

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -22,8 +22,17 @@ import unittest
 import uuid
 import shutil
 import operator
-from itertools import izip
+
 from ctypes import create_string_buffer
+
+# Python3 compatibility
+from builtins import zip
+from builtins import str
+from builtins import next
+from builtins import map
+from builtins import range
+from builtins import open
+from builtins import bytearray
 
 import pydoop.hdfs as hdfs
 import pydoop
@@ -117,8 +126,8 @@ class TestCommon(unittest.TestCase):
         local_fs = hdfs.hdfs('', 0)
         local_wd = utils.make_wd(local_fs)
         from_path = os.path.join(local_wd, uuid.uuid4().hex)
-        content = uuid.uuid4().hex
-        with open(from_path, "w") as f:
+        content = uuid.uuid4().bytes
+        with open(from_path, "wb") as f:
             f.write(content)
         to_path = self._make_random_file()
         local_fs.copy(from_path, self.fs, to_path)
@@ -129,7 +138,7 @@ class TestCommon(unittest.TestCase):
         shutil.rmtree(local_wd)
 
     def move(self):
-        content = uuid.uuid4().hex
+        content = uuid.uuid4().bytes
         from_path = self._make_random_file(content=content)
         to_path = self._make_random_path()
         self.fs.move(from_path, self.fs, to_path)
@@ -139,7 +148,7 @@ class TestCommon(unittest.TestCase):
         self.assertRaises(ValueError, self.fs.move, "", self.fs, "")
 
     def chmod(self):
-        new_perm = 0777
+        new_perm = 0o777
         path = self._make_random_dir()
         old_perm = self.fs.get_path_info(path)["permissions"]
         assert old_perm != new_perm
@@ -156,28 +165,28 @@ class TestCommon(unittest.TestCase):
 
     def chmod_w_string(self):
         path = self._make_random_dir()
-        self.fs.chmod(path, 0500)
+        self.fs.chmod(path, 0o500)
         # each user
-        self.__set_and_check_perm(path, "u+w", 0700)
-        self.__set_and_check_perm(path, "g+w", 0720)
-        self.__set_and_check_perm(path, "o+w", 0722)
+        self.__set_and_check_perm(path, "u+w", 0o700)
+        self.__set_and_check_perm(path, "g+w", 0o720)
+        self.__set_and_check_perm(path, "o+w", 0o722)
         # each permission mode
-        self.__set_and_check_perm(path, "o+r", 0726)
-        self.__set_and_check_perm(path, "o+x", 0727)
+        self.__set_and_check_perm(path, "o+r", 0o726)
+        self.__set_and_check_perm(path, "o+x", 0o727)
         # subtract operation, and multiple permission modes
-        self.__set_and_check_perm(path, "o-rwx", 0720)
+        self.__set_and_check_perm(path, "o-rwx", 0o720)
         # multiple users
         self.__set_and_check_perm(path, "ugo-rwx", 0000)
         # 'a' user
-        self.__set_and_check_perm(path, "a+r", 0444)
+        self.__set_and_check_perm(path, "a+r", 0o444)
         # blank user -- should respect the user's umask
-        umask = os.umask(0007)
+        umask = os.umask(0o007)
         self.fs.chmod(path, "+w")
         perm = self.fs.get_path_info(path)["permissions"]
         os.umask(umask)
-        self.assertEqual(0664, perm)
+        self.assertEqual(0o664, perm)
         # assignment op
-        self.__set_and_check_perm(path, "a=rwx", 0777)
+        self.__set_and_check_perm(path, "a=rwx", 0o777)
 
     def file_attrs(self):
         path = self._make_random_path()
@@ -241,7 +250,8 @@ class TestCommon(unittest.TestCase):
                 chunk = chunk_factory(chunk_size)
                 bytes_read = f.read_chunk(chunk)
                 self.assertEqual(bytes_read, min(size, chunk_size))
-                self.assertEqual(_get_value(chunk), content[:bytes_read])
+                #self.assertEqual(_get_value(chunk), content[:bytes_read])
+                self.assertEqual(chunk[:bytes_read], content[:bytes_read])
 
     def read_chunk(self):
         for factory in bytearray, create_string_buffer:
@@ -333,7 +343,7 @@ class TestCommon(unittest.TestCase):
         with self.fs.open_file(path) as f:
             bytes_read = f.pread_chunk(offset, chunk)
             self.assertEqual(bytes_read, length)
-            self.assertEqual(chunk.value, content[offset: offset + length])
+            self.assertEqual(chunk[:bytes_read], content[offset: offset + length])
             self.assertEqual(f.tell(), 0)
 
     def copy_on_self(self):
@@ -366,12 +376,12 @@ class TestCommon(unittest.TestCase):
         new_d = self._make_random_dir()
 
         self.assertEqual(self.fs.list_directory(new_d), [])
-        paths = [self._make_random_file(where=new_d) for _ in xrange(3)]
+        paths = [self._make_random_file(where=new_d) for _ in range(3)]
         paths.sort(key=os.path.basename)
         infos = self.fs.list_directory(new_d)
         infos.sort(key=lambda p: os.path.basename(p["name"]))
         self.assertEqual(len(infos), len(paths))
-        for i, p in izip(infos, paths):
+        for i, p in zip(infos, paths):
             self.__check_path_info(i, kind="file")
             self.assertTrue(i['name'].endswith(p))
         self.assertRaises(
@@ -410,7 +420,7 @@ class TestCommon(unittest.TestCase):
         self.__check_readline(get_lines)
 
     def readline_big(self):
-        for i in xrange(10, 23):
+        for i in range(10, 23):
             x = '*' * (2**i) + "\n"
             path = self._make_random_file(content=x)
             with self.fs.open_file(path) as f:
@@ -425,7 +435,7 @@ class TestCommon(unittest.TestCase):
             lines = []
             while 1:
                 try:
-                    lines.append(f.next())
+                    lines.append(next(f))
                 except StopIteration:
                     break
             return lines
@@ -500,15 +510,15 @@ class TestCommon(unittest.TestCase):
             )
         top = new_d
         cache = [top]
-        for _ in xrange(2):
+        for _ in range(2):
             cache.append(self._make_random_file(where=top))
         parent = self._make_random_dir(where=top)
         cache.append(parent)
-        for _ in xrange(2):
+        for _ in range(2):
             cache.append(self._make_random_file(where=parent))
         child = self._make_random_dir(where=parent)
         cache.append(child)
-        for _ in xrange(2):
+        for _ in range(2):
             cache.append(self._make_random_file(where=child))
         infos = list(self.fs.walk(top))
         expected_infos = [self.fs.get_path_info(p) for p in cache]
@@ -517,9 +527,9 @@ class TestCommon(unittest.TestCase):
             l.sort(key=operator.itemgetter("name"))
         self.assertEqual(infos, expected_infos)
         nonexistent_walk = self.fs.walk(self._make_random_path())
-        self.assertRaises(IOError, nonexistent_walk.next)
+        self.assertRaises(IOError, nonexistent_walk.__next__)
         for top in '', None:
-            self.assertRaises(ValueError, self.fs.walk(top).next)
+            self.assertRaises(ValueError, self.fs.walk(top).__next__)
 
     def exists(self):
         self.assertFalse(self.fs.exists('some_file'))
@@ -535,7 +545,7 @@ class TestCommon(unittest.TestCase):
                 'permissions', 'block_size', 'last_access', 'size')
         for k in keys:
             self.assertTrue(k in info)
-        for k, exp_v in expected_values.iteritems():
+        for k, exp_v in expected_values.items():
             v = info[k]
             self.assertEqual(v, exp_v)
 

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -250,7 +250,6 @@ class TestCommon(unittest.TestCase):
                 chunk = chunk_factory(chunk_size)
                 bytes_read = f.read_chunk(chunk)
                 self.assertEqual(bytes_read, min(size, chunk_size))
-                #self.assertEqual(_get_value(chunk), content[:bytes_read])
                 self.assertEqual(chunk[:bytes_read], content[:bytes_read])
 
     def read_chunk(self):
@@ -343,7 +342,8 @@ class TestCommon(unittest.TestCase):
         with self.fs.open_file(path) as f:
             bytes_read = f.pread_chunk(offset, chunk)
             self.assertEqual(bytes_read, length)
-            self.assertEqual(chunk[:bytes_read], content[offset: offset + length])
+            self.assertEqual(chunk[:bytes_read],
+                             content[offset: offset + length])
             self.assertEqual(f.tell(), 0)
 
     def copy_on_self(self):
@@ -530,7 +530,7 @@ class TestCommon(unittest.TestCase):
         with self.assertRaises(IOError):
             next(nonexistent_walk)
         for top in '', None:
-            with self.assertRaises(ValueError):            
+            with self.assertRaises(ValueError):
                 next(self.fs.walk(top))
 
     def exists(self):

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -527,9 +527,11 @@ class TestCommon(unittest.TestCase):
             l.sort(key=operator.itemgetter("name"))
         self.assertEqual(infos, expected_infos)
         nonexistent_walk = self.fs.walk(self._make_random_path())
-        self.assertRaises(IOError, nonexistent_walk.__next__)
+        with self.assertRaises(IOError):
+            next(nonexistent_walk)
         for top in '', None:
-            self.assertRaises(ValueError, self.fs.walk(top).__next__)
+            with self.assertRaises(ValueError):            
+                next(self.fs.walk(top))
 
     def exists(self):
         self.assertFalse(self.fs.exists('some_file'))

--- a/test/hdfs/test_hdfs.py
+++ b/test/hdfs/test_hdfs.py
@@ -16,11 +16,17 @@
 #
 # END_COPYRIGHT
 
+from __future__ import division
+from builtins import zip
+from builtins import range
+from builtins import object
+from past.utils import old_div
+
 import unittest
 import tempfile
 import os
 import stat
-from itertools import izip
+
 from threading import Thread
 
 import pydoop.hdfs as hdfs
@@ -38,11 +44,11 @@ class TestHDFS(unittest.TestCase):
         fs.create_directory(wd_bn)
         self.hdfs_wd = fs.get_path_info(wd_bn)["name"]
         fs.close()
-        basenames = ["test_path_%d" % i for i in xrange(2)]
+        basenames = ["test_path_%d" % i for i in range(2)]
         self.local_paths = ["%s/%s" % (self.local_wd, bn) for bn in basenames]
         self.hdfs_paths = ["%s/%s" % (self.hdfs_wd, bn) for bn in basenames]
         self.data = make_random_data(
-            4 * BUFSIZE + BUFSIZE / 2, printable=False
+            4 * BUFSIZE + old_div(BUFSIZE, 2), printable=False
         )
         for path in self.local_paths:
             self.assertTrue(path.startswith("file:"))
@@ -76,7 +82,7 @@ class TestHDFS(unittest.TestCase):
             self.assertEqual(rdata, self.data)
 
     def __ls(self, ls_func, path_transform):
-        for wd, paths in izip(
+        for wd, paths in zip(
             (self.local_wd, self.hdfs_wd), (self.local_paths, self.hdfs_paths)
         ):
             for p in paths:
@@ -182,7 +188,7 @@ class TestHDFS(unittest.TestCase):
     def put(self):
         src = hdfs.path.split(self.local_paths[0])[-1]
         dest = self.hdfs_paths[0]
-        with open(src, "w") as f:
+        with open(src, "wb") as f:
             f.write(self.data)
         hdfs.put(src, dest)
         with hdfs.open(dest) as fi:
@@ -194,7 +200,7 @@ class TestHDFS(unittest.TestCase):
         dest = hdfs.path.split(self.local_paths[0])[-1]
         hdfs.dump(self.data, src)
         hdfs.get(src, dest)
-        with open(dest) as fi:
+        with open(dest, 'rb') as fi:
             rdata = fi.read()
         self.assertEqual(rdata, self.data)
 

--- a/test/hdfs/test_hdfs_fs.py
+++ b/test/hdfs/test_hdfs_fs.py
@@ -16,6 +16,10 @@
 #
 # END_COPYRIGHT
 
+from __future__ import absolute_import
+from __future__ import print_function
+from builtins import range
+
 import unittest
 import getpass
 import socket
@@ -58,7 +62,7 @@ class TestConnection(unittest.TestCase):
             hdfs.hdfs._ALIASES = {"host": {}, "port": {}, "user": {}}  # FIXME
             with hdfs.hdfs(h1, p1) as fs1:
                 with hdfs.hdfs(h2, p2) as fs2:
-                    print ' * %r vs %r' % ((h1, p1), (h2, p2))
+                    print(' * %r vs %r' % ((h1, p1), (h2, p2)))
                     self.assertTrue(fs2.fs is fs1.fs)
                 for fs in fs1, fs2:
                     self.assertFalse(fs.closed)
@@ -73,15 +77,15 @@ class TestHDFS(TestCommon):
 
     def capacity(self):
         c = self.fs.capacity()
-        self.assertTrue(isinstance(c, (int, long)))
+        self.assertTrue(isinstance(c, int))
 
     def default_block_size(self):
         dbs = self.fs.default_block_size()
-        self.assertTrue(isinstance(dbs, (int, long)))
+        self.assertTrue(isinstance(dbs, int))
 
     def used(self):
         u_ = self.fs.used()
-        self.assertTrue(isinstance(u_, (int, long)))
+        self.assertTrue(isinstance(u_, int))
 
     def chown(self):
         new_owner = "nobody"
@@ -122,13 +126,13 @@ class TestHDFS(TestCommon):
 
     def block_size(self):
         if not pydoop.hadoop_version_info().has_deprecated_bs():
-            for bs_MB in xrange(100, 500, 50):
+            for bs_MB in range(100, 500, 50):
                 bs = bs_MB * 2**20
                 path = self._make_random_file(blocksize=bs)
                 self.assertEqual(self.fs.get_path_info(path)["block_size"], bs)
 
     def replication(self):
-        for r in xrange(1, 6):
+        for r in range(1, 6):
             path = self._make_random_file(replication=r)
             self.assertEqual(self.fs.get_path_info(path)["replication"], r)
 
@@ -195,7 +199,7 @@ class TestHDFS(TestCommon):
         content = "x" * blocksize * N
         path = self._make_random_file(content=content, **kwargs)
         start = 0
-        for i in xrange(N):
+        for i in range(N):
             length = blocksize * i + 1
             hosts_per_block = self.fs.get_hosts(path, start, length)
             self.assertEqual(len(hosts_per_block), i + 1)

--- a/test/hdfs/test_hdfs_fs.py
+++ b/test/hdfs/test_hdfs_fs.py
@@ -19,6 +19,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from builtins import range
+from builtins import int
 
 import unittest
 import getpass

--- a/test/hdfs/test_local_fs.py
+++ b/test/hdfs/test_local_fs.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 # BEGIN_COPYRIGHT
 #
 # Copyright 2009-2016 CRS4.
@@ -16,6 +15,8 @@ from __future__ import absolute_import
 # under the License.
 #
 # END_COPYRIGHT
+
+from __future__ import absolute_import
 
 import unittest
 import getpass

--- a/test/hdfs/test_local_fs.py
+++ b/test/hdfs/test_local_fs.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # BEGIN_COPYRIGHT
 #
 # Copyright 2009-2016 CRS4.

--- a/test/hdfs/test_path.py
+++ b/test/hdfs/test_path.py
@@ -16,6 +16,8 @@
 #
 # END_COPYRIGHT
 
+from __future__ import print_function
+
 import sys
 import os
 import unittest
@@ -68,7 +70,7 @@ class TestSplit(unittest.TestCase):
     def good_with_user(self):
         if hdfs.default_is_local():
             cases = [
-                ('a/b', u, ('', 0, 'a/b')) for u in None, DEFAULT_USER, 'foo'
+                ('a/b', u, ('', 0, 'a/b')) for u in (None, DEFAULT_USER, 'foo')
             ]
         else:
             cases = [
@@ -346,7 +348,7 @@ class TestStat(unittest.TestCase):
         info = fs.get_path_info(fn)
         fs.close()
         s = hdfs.path.stat(p)
-        for n1, n2 in self.NMAP.iteritems():
+        for n1, n2 in self.NMAP.items():
             attr = getattr(s, n1, None)
             self.assertFalse(attr is None)
             self.assertEqual(attr, info[n2])
@@ -487,7 +489,7 @@ class TestAccess(unittest.TestCase):
     def __test(self, offset, user=None):
         for mode in os.R_OK, os.W_OK, os.X_OK:
             hdfs.chmod(self.path, mode << offset)
-            print ' * mode now: %03o' % hdfs.path.stat(self.path).st_mode
+            print(' * mode now: %03o' % hdfs.path.stat(self.path).st_mode)
             self.assertTrue(hdfs.path.access(self.path, mode, user=user))
 
     def test_owner(self):


### PR DESCRIPTION
This PR contains compatibility changes to support both py2.7 and >= py3.5.

The changes are mainly concentrated on:
1. the setup.py build and installation system [it compiles and installs in both python versions]
2. the hdfs submodule and related tests [passes all tests in test/hdfs with both python versions]
3. disabled self_contained example, The use of futurize to implement python2 and 3 cohabitation introduces a bunch of new dependencies that need to be packaged and shipped together
with pydoop, which is not particularly elegant. For the time being, I have just
disabled the example.

At least on my laptop, python2.7 builds and runs all the tests. It is likely that the compatibility layer will introduce noticeable overhead.
