### PR TITLE
Allow user override avro jar

### DIFF
--- a/pydoop/app/submit.py
+++ b/pydoop/app/submit.py
@@ -338,8 +338,8 @@ class PydoopSubmitter(object):
         if self.args.libjars:
             libjars.extend(self.args.libjars)
         if self.args.avro_input or self.args.avro_output:
-            # append Pydoop's avro-mapred jar.  Don't put it at the front of the list
-            # or the user won't be able to override it.
+            # append Pydoop's avro-mapred jar.  Don't put it at the front of
+            # the list or the user won't be able to override it.
             avro_jars = glob.glob(os.path.join(
                 pydoop.package_dir(), "avro*.jar"
             ))

--- a/pydoop/hadut.py
+++ b/pydoop/hadut.py
@@ -21,6 +21,7 @@ The hadut module provides access to some functionalities available
 via the Hadoop shell.
 """
 
+import logging
 import os
 import shlex
 import subprocess
@@ -152,7 +153,7 @@ def run_cmd(cmd, args=None, properties=None, hadoop_home=None,
         gargs = _pop_generic_args(args)
         for seq in gargs, args:
             _args.extend(map(str, seq))
-    logger.debug('final args: %r' % (_args,))
+    logger.debug('final args: %r', (_args,))
     if keep_streams:
         p = subprocess.Popen(
             _args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
@@ -161,7 +162,7 @@ def run_cmd(cmd, args=None, properties=None, hadoop_home=None,
         stderr_iterator = iter(p.stderr.readline, b"")
         for line in stderr_iterator:
             error += line
-            logger.info("cmd stderr line: " + line.strip())
+            logger.info("cmd stderr line: %s", line.strip())
 
         output, _ = p.communicate()
     else:
@@ -481,7 +482,7 @@ class PipesRunner(object):
             hdfs.put(input_, self.input)
         else:
             self.input = input_
-            self.logger.info("assigning input to %s" % self.input)
+            self.logger.info("assigning input to %s", self.input)
 
     def set_output(self, output):
         """
@@ -489,7 +490,7 @@ class PipesRunner(object):
         instantiated with a prefix.
         """
         self.output = output
-        self.logger.info("assigning output to %s" % self.output)
+        self.logger.info("assigning output to %s", self.output)
 
     def set_exe(self, pipes_code):
         """
@@ -514,10 +515,11 @@ class PipesRunner(object):
         """
         Run :func:`collect_output` on the job's output directory.
         """
-        self.logger.info("collecting output%s" % (
-            " to %s" % out_file if out_file else ''
-        ))
-        self.logger.info("self.output %s", self.output)
+        if self.logger.isEnabledFor(logging.INFO):
+            self.logger.info("collecting output %s",
+                " to %s" % out_file if out_file else ''
+            )
+            self.logger.info("self.output %s", self.output)
         return collect_output(self.output, out_file)
 
     def __str__(self):

--- a/pydoop/hadut.py
+++ b/pydoop/hadut.py
@@ -299,15 +299,21 @@ def run_class(class_name, args=None, properties=None, classpath=None,
     old_classpath = None
     if classpath:
         old_classpath = os.getenv('HADOOP_CLASSPATH', '')
+        if isinstance(classpath, basestring):
+            classpath = [classpath]
+        # Prepend the classpaths provided by the user to the existing HADOOP_CLASSPATH value.
+        # Order matters.  We could work a little harder to avoid duplicates, but it's not essential
         os.environ['HADOOP_CLASSPATH'] = ":".join(
-            _to_set(old_classpath) | _to_set(classpath)
+            classpath + old_classpath.split(':', 1)
         )
-        logger.debug('HADOOP_CLASSPATH: %r' % (os.getenv('HADOOP_CLASSPATH'),))
-    res = run_cmd(class_name, args, properties,
-                  hadoop_conf_dir=hadoop_conf_dir, logger=logger,
-                  keep_streams=keep_streams)
-    if old_classpath is not None:
-        os.environ['HADOOP_CLASSPATH'] = old_classpath
+        logger.debug('HADOOP_CLASSPATH: %r', os.getenv('HADOOP_CLASSPATH'))
+    try:
+        res = run_cmd(class_name, args, properties,
+                      hadoop_conf_dir=hadoop_conf_dir, logger=logger,
+                      keep_streams=keep_streams)
+    finally:
+        if old_classpath is not None:
+            os.environ['HADOOP_CLASSPATH'] = old_classpath
     return res
 
 

--- a/pydoop/hadut.py
+++ b/pydoop/hadut.py
@@ -302,8 +302,9 @@ def run_class(class_name, args=None, properties=None, classpath=None,
         old_classpath = os.getenv('HADOOP_CLASSPATH', '')
         if isinstance(classpath, basestring):
             classpath = [classpath]
-        # Prepend the classpaths provided by the user to the existing HADOOP_CLASSPATH value.
-        # Order matters.  We could work a little harder to avoid duplicates, but it's not essential
+        # Prepend the classpaths provided by the user to the existing
+        # HADOOP_CLASSPATH value.  Order matters.  We could work a little
+        # harder to avoid duplicates, but it's not essential
         os.environ['HADOOP_CLASSPATH'] = ":".join(
             classpath + old_classpath.split(':', 1)
         )
@@ -516,8 +517,8 @@ class PipesRunner(object):
         Run :func:`collect_output` on the job's output directory.
         """
         if self.logger.isEnabledFor(logging.INFO):
-            self.logger.info("collecting output %s",
-                " to %s" % out_file if out_file else ''
+            self.logger.info(
+                "collecting output %s", " to %s" % out_file if out_file else ''
             )
             self.logger.info("self.output %s", self.output)
         return collect_output(self.output, out_file)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 ignore = E402
-exclude = hadoop*
+exclude = hadoop*,build


### PR DESCRIPTION
This PR changes pydoop's behaviour as to append its jars to the `-libjars` and `HADOOP_CLASSPATH` rather than prepend them.  This change allows a client application to override Pydoop's jars with its own.  This is especially important for the avro classes, since a user might need to use a version different from the one packaged with Pydoop.