### PR TITLE
Support for text I/O

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -1,0 +1,14 @@
+FROM crs4/pydoop
+MAINTAINER simone.leo@crs4.it
+
+RUN yum install inkscape  # installs ImageMagick as a dep
+RUN pip3 install sphinx
+
+RUN inkscape -z -D -f logo/logo.svg -e /tmp/logo.png -w 800 && \
+    convert -resize 200x /tmp/logo.png docs/_static/logo.png
+RUN inkscape -z -D -f logo/favicon.svg -e /tmp/256.png -w 256 -h 256 && \
+    for i in 16 32 64 128; do \
+        convert /tmp/256.png -resize ${i}x${i} /tmp/${i}.png; \
+    done && \
+    convert /tmp/{16,32,64,128}.png docs/_static/favicon.ico
+RUN source /etc/profile && make -C docs html

--- a/docs/api_docs/hdfs_api.rst
+++ b/docs/api_docs/hdfs_api.rst
@@ -14,3 +14,6 @@
 
 .. automodule:: pydoop.hdfs.file
    :members:
+
+.. automodule:: pydoop.hdfs.common
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ CURRENT_YEAR = datetime.datetime.now().year
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
-    'sphinx.ext.pngmath',
+    'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinx.ext.intersphinx'
 ]

--- a/examples/hdfs/treegen.py
+++ b/examples/hdfs/treegen.py
@@ -35,7 +35,7 @@ BS_RANGE = [_ * MB for _ in range(50, 101, 10)]
 def treegen(fs, root, depth, span):
     if isdir(fs, root) and depth > 0:
         for i in range(span):
-            path = "%s/%d_%d" % (root, depth, i)
+            path = u"%s/%d_%d" % (root, depth, i)
             kind = 'file' if i else 'directory'
             if kind == 'file':
                 kwargs = {}
@@ -47,7 +47,7 @@ def treegen(fs, root, depth, span):
                 sys.stderr.write(
                     "%s %s %d\n" % (kind[0].upper(), path, (bs / MB))
                 )
-                with fs.open_file(path, "w", **kwargs) as f:
+                with fs.open_file(path, "wt", **kwargs) as f:
                     f.write(path)
             else:
                 sys.stderr.write("%s %s 0\n" % (kind[0].upper(), path))

--- a/examples/input_format/check_results.py
+++ b/examples/input_format/check_results.py
@@ -31,9 +31,8 @@ def get_res(output_dir):
     data = []
     for x in fs.list_directory(output_dir):
         if os.path.split(x['path'])[-1].startswith('part-'):
-            with fs.open_file(x['path']) as f:
-                # TODO: add unicode I/O to hdfs
-                data.append(f.read().decode('utf8'))
+            with fs.open_file(x['path'], 'rt') as f:
+                data.append(f.read())
     all_data = ''.join(data)
     return pts.parse_mr_output(all_data, vtype=int)
 

--- a/examples/self_contained/check_results.py
+++ b/examples/self_contained/check_results.py
@@ -32,8 +32,8 @@ def compute_vc(input_dir):
     fs = hdfs()
     data = []
     for x in fs.list_directory(input_dir):
-        with fs.open_file(x['path']) as f:
-            data.append(f.read().decode("utf8"))
+        with fs.open_file(x['path'], 'rt') as f:
+            data.append(f.read())
     all_data = ''.join(data)
     vowels = re.findall('[AEIOUY]', all_data.upper())
     return Counter(vowels)

--- a/examples/wordcount/bin/wordcount-full.py
+++ b/examples/wordcount/bin/wordcount-full.py
@@ -56,7 +56,8 @@ class Mapper(pp.Mapper):
         self.input_words = context.getCounter(WORDCOUNT, INPUT_WORDS)
 
     def map(self, context):
-        words = re.sub('[^0-9a-zA-Z]+', ' ', context.getInputValue()).split()
+        value = context.getInputValue().decode("utf-8")
+        words = re.sub('[^0-9a-zA-Z]+', ' ', value).split()
         for w in words:
             context.emit(w, "1")
         context.incrementCounter(self.input_words, len(words))
@@ -115,7 +116,7 @@ class Reader(pp.RecordReader):
             return (False, "", "")
         key = struct.pack(">q", self.isplit.offset + self.bytes_read)
         record = self.file.readline()
-        if record == "":  # end of file
+        if not record:  # end of file
             return (False, "", "")
         self.bytes_read += len(record)
         return (True, key, record)

--- a/pydoop/hadut.py
+++ b/pydoop/hadut.py
@@ -30,7 +30,7 @@ import pydoop
 import pydoop.utils.misc as utils
 import pydoop.hadoop_utils as hu
 import pydoop.hdfs as hdfs
-from .utils.py3compat import basestring, bintype
+from .utils.py3compat import basestring
 
 
 GLOB_CHARS = frozenset('*,?[]{}')
@@ -418,10 +418,9 @@ def collect_output(mr_out_dir, out_file=None):
     if out_file is None:
         output = []
         for fn in iter_mr_out_files(mr_out_dir):
-            with hdfs.open(fn) as f:
+            with hdfs.open(fn, "rt") as f:
                 output.append(f.read())
-        # TODO: add unicode I/O to hdfs
-        return bintype().join(output).decode("utf8")
+        return "".join(output)
     else:
         block_size = 16777216
         with open(out_file, 'a') as o:

--- a/pydoop/hdfs/common.py
+++ b/pydoop/hdfs/common.py
@@ -42,6 +42,15 @@ TEXT_ENCODING = 'utf-8'
 
 
 class Mode(object):
+    """\
+    File opening mode.
+
+    Can be initialized either with a string or an integer. In the
+    former case, semantics are the same as in ``io.open``, but only
+    ``'r', 'w', 'a', 'rb', 'wb'`` and ``'ab'`` are supported. In the
+    latter, supported modes are :data:`os.O_RDONLY`, :data:`os.O_WRONLY`
+    and :data:`os.O_WRONLY` | :data:`os.O_APPEND`.
+    """
 
     VALUE = {
         "r": os.O_RDONLY,

--- a/pydoop/hdfs/common.py
+++ b/pydoop/hdfs/common.py
@@ -24,6 +24,7 @@ import getpass
 import pwd
 import grp
 import sys
+import os
 
 __is_py3 = sys.version_info >= (3, 0)
 
@@ -38,6 +39,62 @@ TEXT_ENCODING = 'utf-8'
 # We use UTF-8 since this is what the Hadoop TextFileFormat uses
 # NOTE:  If you change this, you'll also need to fix the encoding
 # used by the native extension.
+
+
+class Mode(object):
+
+    VALUE = {
+        "r": os.O_RDONLY,
+        "w": os.O_WRONLY,
+        "a": os.O_WRONLY | os.O_APPEND,
+    }
+
+    FLAGS = {
+        os.O_RDONLY: "r",
+        os.O_WRONLY: "w",
+        os.O_WRONLY | os.O_APPEND: "a",
+    }
+
+    @property
+    def value(self):
+        return self.__value
+
+    @property
+    def flags(self):
+        return self.__flags
+
+    @property
+    def binary(self):
+        return self.__binary
+
+    def __init__(self, m=None):
+        self.__value = "r"
+        self.__flags = os.O_RDONLY
+        self.__binary = False
+        if not m:
+            return
+        try:
+            self.__value = m[0]
+        except TypeError:
+            try:
+                self.__value = Mode.FLAGS[m]
+            except KeyError:
+                self.__error(m)
+            else:
+                self.__flags = m
+        else:
+            try:
+                self.__flags = Mode.VALUE[self.__value]
+            except KeyError:
+                self.__error(m)
+            else:
+                try:
+                    self.__binary = m[1] == "b"
+                except IndexError:
+                    pass
+
+    def __error(self, m):
+        raise ValueError("invalid mode: %r" % (m,))
 
 
 if __is_py3:

--- a/pydoop/hdfs/file.py
+++ b/pydoop/hdfs/file.py
@@ -139,15 +139,15 @@ class hdfs_file(object):
         :type errors: str
 
         :param errors: The error handling scheme to use for the handling of
-        decoding errors. The default is 'strict' meaning that decoding errors
-        raise a UnicodeDecodeError. Other possible values are 'ignore' and
-        'replace' as well as any other name registered  with
-        codecs.register_error that can handle UnicodeDecodeErrors.
+          decoding errors. The default is 'strict' meaning that decoding errors
+          raise a UnicodeDecodeError. Other possible values are 'ignore' and
+          'replace' as well as any other name registered  with
+          codecs.register_error that can handle UnicodeDecodeErrors.
 
         :rtype: str
 
         :return: the next line of text in the file, including the
-        newline character
+          newline character
         """
         _complain_ifclosed(self.closed)
         eol = self.__read_chunks_until_nl()
@@ -446,15 +446,15 @@ class local_file(FileIO):
         :type errors: str
 
         :param errors: The error handling scheme to use for the handling of
-        decoding errors. The default is 'strict' meaning that decoding errors
-        raise a UnicodeDecodeError. Other possible values are 'ignore' and
-        'replace' as well as any other name registered
-        with codecs.register_error that can handle UnicodeDecodeErrors.
+          decoding errors. The default is 'strict' meaning that decoding errors
+          raise a UnicodeDecodeError. Other possible values are 'ignore' and
+          'replace' as well as any other name registered
+          with codecs.register_error that can handle UnicodeDecodeErrors.
 
         :rtype: str
 
         :return: the next line of text in the file, including the
-        newline character
+          newline character
         """
         line = super(local_file, self).readline()
         if encoding is None:  # FIXME: add support for "rb" mode to hdfs_file

--- a/pydoop/test_utils.py
+++ b/pydoop/test_utils.py
@@ -61,7 +61,7 @@ def _get_special_chr():
         msg = ("local file system doesn't support unicode characters"
                "in filenames, falling back to ASCII-only")
         warnings.warn(msg, UnicodeWarning)
-        the_chr = 's'
+        the_chr = u's'
     finally:
         if fd:
             os.close(fd)

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -269,10 +269,6 @@ class TestCommon(unittest.TestCase):
         with self.fs.open_file(path, "w") as fo:
             bytes_written = fo.write(chunk)
             self.assertEqual(bytes_written, len(content))
-        with self.fs.open_file(path, "wt") as fo:
-            text = u'a string' + utils.UNI_CHR
-            chars_written = fo.write(text)
-            self.assertEqual(chars_written, len(text))
 
     def write_chunk(self):
         content = utils.make_random_data()
@@ -530,6 +526,21 @@ class TestCommon(unittest.TestCase):
         self.assertTrue(self.fs.exists(fname))
         self.assertRaises(ValueError, self.fs.exists, "")
 
+    def text_io(self):
+        t_path, b_path = self._make_random_path(), self._make_random_path()
+        text = u'a string' + utils.UNI_CHR
+        data = text.encode("utf-8")
+        with self.fs.open_file(t_path, "wt") as fo:
+            chars_written = fo.write(text)
+        with self.fs.open_file(b_path, "w") as fo:
+            bytes_written = fo.write(data)
+        self.assertEqual(chars_written, len(text))
+        self.assertEqual(bytes_written, len(data))
+        with self.fs.open_file(t_path, "rt") as f:
+            self.assertEqual(f.read(), text)
+        with self.fs.open_file(b_path, "r") as f:
+            self.assertEqual(f.read(), data)
+
     def __check_path_info(self, info, **expected_values):
         keys = ('kind', 'group', 'name', 'last_mod', 'replication', 'owner',
                 'permissions', 'block_size', 'last_access', 'size')
@@ -571,4 +582,5 @@ def common_tests():
         'block_boundary',
         'walk',
         'exists',
+        'text_io',
     ]

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -96,9 +96,8 @@ class TestCommon(unittest.TestCase):
             path = self._make_random_path()
             self.fs.open_file(path, flags).close()
             for flags in "r", os.O_RDONLY:
-                f = self.fs.open_file(path, flags)
-                self.assertFalse(f.closed)
-                f.close()
+                with self.fs.open_file(path, flags) as f:
+                    self.assertFalse(f.closed)
                 self.assertTrue(f.closed)
                 self.assertRaises(ValueError, f.read)
         path = self._make_random_path()
@@ -190,14 +189,14 @@ class TestCommon(unittest.TestCase):
         with self.fs.open_file(path, os.O_WRONLY) as f:
             self.assertTrue(f.name.endswith(path))
             self.assertEqual(f.size, 0)
-            self.assertEqual(f.mode, "w")
+            self.assertEqual(f.mode, "wb")
             content = utils.make_random_data()
             f.write(content)
         self.assertEqual(f.size, len(content))
         with self.fs.open_file(path) as f:
             self.assertTrue(f.name.endswith(path))
             self.assertEqual(f.size, len(content))
-            self.assertEqual(f.mode, "r")
+            self.assertEqual(f.mode, "rb")
 
     def flush(self):
         path = self._make_random_path()
@@ -236,7 +235,7 @@ class TestCommon(unittest.TestCase):
         with self.fs.open_file(path) as f:
             self.assertEqual(f.read(3), content[:3])
             self.assertEqual(f.read(3), content[3:6])
-            self.assertRaisesExternal(IOError, f.write, content)
+            self.assertRaisesExternal(ValueError, f.write, content)
 
     def __read_chunk(self, chunk_factory):
         content = utils.make_random_data()
@@ -270,14 +269,10 @@ class TestCommon(unittest.TestCase):
         with self.fs.open_file(path, "w") as fo:
             bytes_written = fo.write(chunk)
             self.assertEqual(bytes_written, len(content))
-        with self.fs.open_file(path, "w") as fo:
-            bytes_written = fo.write(u'some unicode data')
-        # try to write a unicode object
-        with self.fs.open_file(path, "w") as fo:
-            u = u'a string' + utils.UNI_CHR
-            data = u.encode('utf-8')
-            bytes_written = fo.write(u)
-            self.assertEqual(bytes_written, len(data))
+        with self.fs.open_file(path, "wt") as fo:
+            text = u'a string' + utils.UNI_CHR
+            chars_written = fo.write(text)
+            self.assertEqual(chars_written, len(text))
 
     def write_chunk(self):
         content = utils.make_random_data()
@@ -383,11 +378,11 @@ class TestCommon(unittest.TestCase):
 
     def __check_readline(self, get_lines):
         samples = [
-            "foo\nbar\n\ntar",
-            "\nfoo\nbar\n\ntar",
-            "foo\nbar\n\ntar\n",
-            "\n\n\n", "\n", "",
-            "foobartar",
+            b"foo\nbar\n\ntar",
+            b"\nfoo\nbar\n\ntar",
+            b"foo\nbar\n\ntar\n",
+            b"\n\n\n", b"\n", b"",
+            b"foobartar",
         ]
         path = self._make_random_path()
         for text in samples:
@@ -413,7 +408,7 @@ class TestCommon(unittest.TestCase):
 
     def readline_big(self):
         for i in range(10, 23):
-            x = '*' * (2**i) + "\n"
+            x = b"*" * (2**i) + b"\n"
             path = self._make_random_file(content=x)
             with self.fs.open_file(path) as f:
                 line = f.readline()
@@ -439,12 +434,12 @@ class TestCommon(unittest.TestCase):
             self.__check_readline(fun)
 
     def seek(self):
-        lines = ["1\n", "2\n", "3\n"]
-        text = "".join(lines)
+        lines = [b"1\n", b"2\n", b"3\n"]
+        data = b"".join(lines)
         path = self._make_random_path()
-        for chunk_size in range(1, 2 + len(text)):
+        for chunk_size in range(1, 2 + len(data)):
             with self.fs.open_file(path, "w") as f:
-                f.write(text)
+                f.write(data)
             with self.fs.open_file(path, readline_chunk_size=chunk_size) as f:
                 for i, l in enumerate(lines):
                     f.seek(sum(map(len, lines[:i])))
@@ -458,9 +453,9 @@ class TestCommon(unittest.TestCase):
                 f.seek(1, os.SEEK_CUR)
                 self.assertEqual(f.tell(), 2)
                 f.seek(-1, os.SEEK_END)
-                self.assertEqual(f.tell(), len(text) - 1)
+                self.assertEqual(f.tell(), len(data) - 1)
                 # seek past end of file
-                self.assertRaises(IOError, f.seek, len(text) + 10)
+                self.assertRaises(IOError, f.seek, len(data) + 10)
 
     def block_boundary(self):
         hd_info = pydoop.hadoop_version_info()
@@ -479,7 +474,7 @@ class TestCommon(unittest.TestCase):
             i = 0
             bufsize = 12 * 1024 * 1024
             while i < total_data_size:
-                data = 'X' * min(bufsize, total_data_size - i)
+                data = b'X' * min(bufsize, total_data_size - i)
                 f.write(data)
                 i += bufsize
 

--- a/test/hdfs/test_common.py
+++ b/test/hdfs/test_common.py
@@ -1,0 +1,65 @@
+# BEGIN_COPYRIGHT
+#
+# Copyright 2009-2017 CRS4.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# END_COPYRIGHT
+
+import unittest
+import os
+
+from pydoop.hdfs.common import Mode
+
+
+class TestHDFSCommon(unittest.TestCase):
+
+    def test_mode(self):
+        keys = ("arg", "value", "flags", "binary")
+        for t in [
+            ("r", "r", os.O_RDONLY, False),
+            ("rt", "r", os.O_RDONLY, False),
+            ("rb", "r", os.O_RDONLY, True),
+            (os.O_RDONLY, "r", os.O_RDONLY, False),
+            ("w", "w", os.O_WRONLY, False),
+            ("wt", "w", os.O_WRONLY, False),
+            ("wb", "w", os.O_WRONLY, True),
+            (os.O_WRONLY, "w", os.O_WRONLY, False),
+            ("a", "a", os.O_WRONLY | os.O_APPEND, False),
+            ("at", "a", os.O_WRONLY | os.O_APPEND, False),
+            ("ab", "a", os.O_WRONLY | os.O_APPEND, True),
+            (os.O_WRONLY | os.O_APPEND, "a", os.O_WRONLY | os.O_APPEND, False),
+        ]:
+            d = dict(zip(keys, t))
+            m = Mode(d.pop('arg'))
+            for k, v in d.items():
+                self.assertEqual(getattr(m, k), v)
+        # default
+        m = Mode()
+        self.assertEqual(m.value, "r")
+        self.assertEqual(m.flags, os.O_RDONLY)
+        self.assertFalse(m.binary)
+        # exceptions
+        for arg in (-1, "k", [0]):
+            self.assertRaises(ValueError, Mode, arg)
+
+
+def suite():
+    suite_ = unittest.TestSuite()
+    suite_.addTest(TestHDFSCommon("test_mode"))
+    return suite_
+
+
+if __name__ == '__main__':
+    _RUNNER = unittest.TextTestRunner(verbosity=2)
+    _RUNNER.run((suite()))

--- a/test/hdfs/test_hdfs.py
+++ b/test/hdfs/test_hdfs.py
@@ -63,7 +63,7 @@ class TestHDFS(unittest.TestCase):
     def open(self):
         for test_path in self.hdfs_paths[0], self.local_paths[0]:
             with hdfs.open(test_path, "w") as f:
-                f.write(self.data, encoding=None)
+                f.write(self.data)
             f.fs.close()
             with hdfs.open(test_path) as f:
                 self.assertEqual(f.read(), self.data)

--- a/test/hdfs/test_hdfs_fs.py
+++ b/test/hdfs/test_hdfs_fs.py
@@ -147,7 +147,7 @@ class TestHDFS(TestCommon):
             chunk_size = min(bs, 12 * 1048576)
             written = 0
             while written < size:
-                data = 'X' * min(chunk_size, size - written)
+                data = b'X' * min(chunk_size, size - written)
                 written += f.write(data)
 
         hd_info = pydoop.hadoop_version_info()
@@ -159,7 +159,7 @@ class TestHDFS(TestCommon):
             bs = 1048576
             kwargs['blocksize'] = bs
 
-        line = "012345678\n"
+        line = b"012345678\n"
         offset = bs - (10 * len(line) + 5)
         path = self._make_random_path()
         with self.fs.open_file(path, flags="w", **kwargs) as f:

--- a/test/hdfs/test_path.py
+++ b/test/hdfs/test_path.py
@@ -365,7 +365,7 @@ class TestStat(unittest.TestCase):
             host = ""
         fs = hdfs.hdfs(host, 0)
         with fs.open_file(p_, 'w') as fo:
-            fo.write(make_random_str())
+            fo.write(b"foobar\n")
         info = fs.get_path_info(p_)
         fs.close()
         s = hdfs.path.stat(p)


### PR DESCRIPTION
With this PR, `hdfs.open` behaves similarly to `io.open`:

```python
>>> import pydoop.hdfs as hdfs
>>> hdfs.mkdir("test")
True
>>> with hdfs.open("test/foo.bin", "wb") as f:
...     f.write(b"foo")
... 
3
>>> with hdfs.open("test/foo.bin", "rb") as f:
...     print(repr(f.read()))
... 
b'foo'
>>> with hdfs.open("test/foo.bin", "rt") as f:
...     print(repr(f.read()))
... 
'foo'
>>> with hdfs.open("test/foo.txt", "wt") as f:
...     f.write("foo")
... 
3
>>> with hdfs.open("test/foo.txt") as f:  # default = binary
...     print(repr(f.read()))
... 
b'foo'
```

The main differences are:

* By default, files are opened in binary mode (for backwards compatibility).
* Opening files for updating (`+`) is not supported (not supported by HDFS files).

The PR also adds a Dockerfile that can be used to build the docs:

```
docker build -t crs4/pydoop-docs -f Dockerfile.docs .
```
