### PR TITLE
Pydoop script: use new API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ before_install: pip install flake8
 # skip installation, requirements are handled in the Docker image
 install: true
 
-before_script: flake8 -v .
+before_script:
+  - flake8 -v .
+  - DEBUG=true ./.travis/check_script_template -v
 
 script:
  - docker build -t crs4/pydoop .

--- a/.travis/check_script_template
+++ b/.travis/check_script_template
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[ -n "${DEBUG:-}" ] && set -x
+this="${BASH_SOURCE-$0}"
+this_dir=$(cd -P -- "$(dirname -- "${this}")" && pwd -P)
+
+export PYTHON="python${TRAVIS_PYTHON_VERSION%.*}"
+${PYTHON} "${this_dir}/check_script_template.py" "$@"

--- a/.travis/check_script_template.py
+++ b/.travis/check_script_template.py
@@ -18,17 +18,14 @@ sys.path.append(os.path.join(THIS_DIR, os.pardir, "pydoop", "app"))
 from script_template import DRIVER_TEMPLATE
 
 
-SUBST = {
-    "module": "module",
-    "map_fn": "map_fn",
-    "reduce_fn": "reduce_fn",
-    "combine_fn": "combine_fn",
-    "combiner_wp": "None",
-}
-
-
 def main(argv):
-    code = DRIVER_TEMPLATE % SUBST
+    code = DRIVER_TEMPLATE.substitute(
+        module="module",
+        map_fn="map_fn",
+        reduce_fn="reduce_fn",
+        combine_fn="combine_fn",
+        combiner_wp="None",
+    )
     fd = None
     try:
         fd, fn = tempfile.mkstemp(suffix=".py", text=True)

--- a/.travis/check_script_template.py
+++ b/.travis/check_script_template.py
@@ -1,0 +1,51 @@
+"""\
+Perform full substitution on the Pydoop script template and check
+it with flake8.
+
+Any options (i.e., arguments starting with at least a dash) are passed
+through to flake8.
+"""
+
+import sys
+import os
+import tempfile
+
+from flake8.main.cli import main as flake8_main
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(THIS_DIR, os.pardir, "pydoop", "app"))
+from script_template import DRIVER_TEMPLATE
+
+
+SUBST = {
+    "module": "module",
+    "map_fn": "map_fn",
+    "reduce_fn": "reduce_fn",
+    "combine_fn": "combine_fn",
+    "combiner_wp": "None",
+}
+
+
+def main(argv):
+    code = DRIVER_TEMPLATE % SUBST
+    fd = None
+    try:
+        fd, fn = tempfile.mkstemp(suffix=".py", text=True)
+        os.write(fd, code.encode("utf-8"))
+    finally:
+        if fd is not None:
+            os.close(fd)
+    flake8_argv = [fn] + [_ for _ in argv if _.startswith("-")]
+    try:
+        flake8_main(flake8_argv)
+    finally:
+        os.remove(fn)
+
+
+if __name__ == "__main__":
+    argv = sys.argv[1:]
+    if set(argv).intersection(["-h", "--help"]):
+        print(__doc__)
+    else:
+        main(argv)

--- a/pydoop/app/script.py
+++ b/pydoop/app/script.py
@@ -47,6 +47,7 @@ DESCRIPTION = "Simplified interface for running simple MapReduce jobs"
 
 
 class PydoopScript(object):
+
     def __init__(self, args, unknown_args):
         self.script_archive = None
         self.args = None
@@ -54,17 +55,15 @@ class PydoopScript(object):
 
     @staticmethod
     def generate_driver(mr_module, args):
-        lines = []
-        template_args = {
-            'module': mr_module,
-            'map_fn': args.map_fn,
-            'reduce_fn': args.reduce_fn,
-            'combine_fn': args.combine_fn or args.reduce_fn,
-            'combiner_wp': ('PydoopScriptCombiner' if args.combine_fn
-                            else 'None')
-        }
-        lines.append(DRIVER_TEMPLATE % template_args)
-        return os.linesep.join(lines) + os.linesep
+        combine_fn = args.combine_fn or args.reduce_fn
+        combiner_wp = 'PydoopScriptCombiner' if args.combine_fn else 'None'
+        return DRIVER_TEMPLATE.substitute(
+            module=mr_module,
+            map_fn=args.map_fn,
+            reduce_fn=args.reduce_fn,
+            combine_fn=combine_fn,
+            combiner_wp=combiner_wp,
+        )
 
     def convert_args(self, args, unknown_args):
         # Create a zip archive containing all we need to run the

--- a/pydoop/app/script_template.py
+++ b/pydoop/app/script_template.py
@@ -5,9 +5,9 @@ import inspect
 
 sys.path.insert(0, os.getcwd())
 
-from pydoop.mapreduce.pipes import run_task
-import pydoop.pipes
-import %(module)s
+from pydoop.mapreduce.pipes import run_task  # noqa: E402
+import pydoop.pipes  # noqa: E402
+import %(module)s  # noqa: E402
 
 
 class ContextWriter(object):
@@ -21,7 +21,8 @@ class ContextWriter(object):
 
     def count(self, what, howmany):
         counter = self.counters.setdefault(
-          what, self.context.getCounter('%(module)s', what))
+            what, self.context.getCounter('%(module)s', what)
+        )
         self.context.incrementCounter(counter, howmany)
 
     def status(self, msg):
@@ -57,8 +58,10 @@ def setup_script_object(obj, fn_attr_name, user_fn, ctx):
     obj.conf = ctx.getJobConf()
     spec = inspect.getargspec(user_fn)
     if spec.varargs or len(spec.args) not in (3, 4):
-        raise ValueError(user_fn +
-           ' must take parameters key, value, writer, and optionally config)')
+        raise ValueError(
+            user_fn +
+            ' must take parameters key, value, writer, and optionally config'
+        )
     if len(spec.args) == 3:
         setattr(obj, fn_attr_name, obj.without_conf)
     elif len(spec.args) == 4:
@@ -81,8 +84,9 @@ class PydoopScriptMapper(pydoop.pipes.Mapper):
     def with_conf(self, ctx):
         # new style map function, without the conf parameter
         writer = ContextWriter(ctx)
-        %(module)s.%(map_fn)s(ctx.getInputKey(), ctx.getInputValue(),
-                              writer, self.conf)
+        %(module)s.%(map_fn)s(
+            ctx.getInputKey(), ctx.getInputValue(), writer, self.conf
+        )
 
     def map(self, ctx):
         pass
@@ -107,8 +111,9 @@ class PydoopScriptReducer(pydoop.pipes.Reducer):
     def with_conf(self, ctx):
         key = ctx.getInputKey()
         writer = ContextWriter(ctx)
-        %(module)s.%(reduce_fn)s(key, PydoopScriptReducer.iter(ctx),
-                                 writer, self.conf)
+        %(module)s.%(reduce_fn)s(
+            key, PydoopScriptReducer.iter(ctx), writer, self.conf
+        )
 
     def reduce(self, ctx):
         pass
@@ -133,8 +138,9 @@ class PydoopScriptCombiner(pydoop.pipes.Combiner):
     def with_conf(self, ctx):
         key = ctx.getInputKey()
         writer = ContextWriter(ctx)
-        %(module)s.%(combine_fn)s(key, PydoopScriptReducer.iter(ctx),
-                                  writer, self.conf)
+        %(module)s.%(combine_fn)s(
+            key, PydoopScriptReducer.iter(ctx), writer, self.conf
+        )
 
     def reduce(self, ctx):
         pass

--- a/pydoop/app/script_template.py
+++ b/pydoop/app/script_template.py
@@ -1,10 +1,14 @@
-DRIVER_TEMPLATE = """
-import sys, os, inspect
+DRIVER_TEMPLATE = """\
+import sys
+import os
+import inspect
+
 sys.path.insert(0, os.getcwd())
 
 from pydoop.mapreduce.pipes import run_task
 import pydoop.pipes
 import %(module)s
+
 
 class ContextWriter(object):
 
@@ -25,6 +29,7 @@ class ContextWriter(object):
 
   def progress(self):
     self.context.progress()
+
 
 def setup_script_object(obj, fn_attr_name, user_fn, ctx):
   # Generic constructor for both map and reduce objects.
@@ -62,6 +67,7 @@ def setup_script_object(obj, fn_attr_name, user_fn, ctx):
     raise RuntimeError(
         'Unexpected number of %(map_fn)s arguments ' + len(spec.args))
 
+
 class PydoopScriptMapper(pydoop.pipes.Mapper):
   def __init__(self, ctx):
     super(type(self), self).__init__(ctx)
@@ -81,7 +87,9 @@ class PydoopScriptMapper(pydoop.pipes.Mapper):
   def map(self, ctx):
     pass
 
+
 class PydoopScriptReducer(pydoop.pipes.Reducer):
+
   def __init__(self, ctx):
     super(type(self), self).__init__(ctx)
     setup_script_object(self, 'reduce', %(module)s.%(reduce_fn)s, ctx)
@@ -105,7 +113,9 @@ class PydoopScriptReducer(pydoop.pipes.Reducer):
   def reduce(self, ctx):
     pass
 
+
 class PydoopScriptCombiner(pydoop.pipes.Combiner):
+
   def __init__(self, ctx):
     super(type(self), self).__init__(ctx)
     setup_script_object(self, 'reduce', %(module)s.%(combine_fn)s, ctx)
@@ -129,11 +139,12 @@ class PydoopScriptCombiner(pydoop.pipes.Combiner):
   def reduce(self, ctx):
     pass
 
+
 def main():
-    result = run_task(
-    pydoop.pipes.Factory(
+    run_task(pydoop.pipes.Factory(
         PydoopScriptMapper, PydoopScriptReducer,
         record_reader_class=None,
-        record_writer_class=None, combiner_class=%(combiner_wp)s,
+        record_writer_class=None,
+        combiner_class=%(combiner_wp)s,
         partitioner_class=None))
 """

--- a/pydoop/app/script_template.py
+++ b/pydoop/app/script_template.py
@@ -12,132 +12,132 @@ import %(module)s
 
 class ContextWriter(object):
 
-  def __init__(self, context):
-    self.context = context
-    self.counters = {}
+    def __init__(self, context):
+        self.context = context
+        self.counters = {}
 
-  def emit(self, k, v):
-    self.context.emit(k, v)
+    def emit(self, k, v):
+        self.context.emit(k, v)
 
-  def count(self, what, howmany):
-    counter = self.counters.setdefault(
-      what, self.context.getCounter('%(module)s', what))
-    self.context.incrementCounter(counter, howmany)
+    def count(self, what, howmany):
+        counter = self.counters.setdefault(
+          what, self.context.getCounter('%(module)s', what))
+        self.context.incrementCounter(counter, howmany)
 
-  def status(self, msg):
-    self.context.setStatus(msg)
+    def status(self, msg):
+        self.context.setStatus(msg)
 
-  def progress(self):
-    self.context.progress()
+    def progress(self):
+        self.context.progress()
 
 
 def setup_script_object(obj, fn_attr_name, user_fn, ctx):
-  # Generic constructor for both map and reduce objects.
-  #
-  # Sets the 'writer' and 'conf' attributes.  Then, based on the arity
-  # of the given user function (user_fn), sets the object attribute
-  # (fn_attr_name, which should be either 'map' or 'reduce') to point
-  # to either:
-  #
-  #   * obj.with_conf (when arity == 4)
-  #   * obj.without_conf (when arity == 3)
-  #
-  # This way, when pipes calls the map/reduce function of the object
-  # it actually gets either of the with_conf/without_conf functions
-  # (which must be defined by the PydoopScriptMapper or
-  # PydoopScriptReducer object passed into this function).
-  #
-  # Why all this?  The idea is to raise any decision about which
-  # function to call out of the map/reduce functions, which get called
-  # a number of times proportional to the amount of data to process.
-  # On the other hand, the constructor only gets called once per task.
-  if fn_attr_name not in ('map', 'reduce'):
-    raise RuntimeError('Unexpected function attribute ' + fn_attr_name)
-  obj.writer = ContextWriter(ctx)
-  obj.conf = ctx.getJobConf()
-  spec = inspect.getargspec(user_fn)
-  if spec.varargs or len(spec.args) not in (3, 4):
-    raise ValueError(user_fn +
-       ' must take parameters key, value, writer, and optionally config)')
-  if len(spec.args) == 3:
-    setattr(obj, fn_attr_name, obj.without_conf)
-  elif len(spec.args) == 4:
-    setattr(obj, fn_attr_name, obj.with_conf)
-  else:
-    raise RuntimeError(
-        'Unexpected number of %(map_fn)s arguments ' + len(spec.args))
+    # Generic constructor for both map and reduce objects.
+    #
+    # Sets the 'writer' and 'conf' attributes.  Then, based on the arity
+    # of the given user function (user_fn), sets the object attribute
+    # (fn_attr_name, which should be either 'map' or 'reduce') to point
+    # to either:
+    #
+    #   * obj.with_conf (when arity == 4)
+    #   * obj.without_conf (when arity == 3)
+    #
+    # This way, when pipes calls the map/reduce function of the object
+    # it actually gets either of the with_conf/without_conf functions
+    # (which must be defined by the PydoopScriptMapper or
+    # PydoopScriptReducer object passed into this function).
+    #
+    # Why all this?  The idea is to raise any decision about which
+    # function to call out of the map/reduce functions, which get called
+    # a number of times proportional to the amount of data to process.
+    # On the other hand, the constructor only gets called once per task.
+    if fn_attr_name not in ('map', 'reduce'):
+        raise RuntimeError('Unexpected function attribute ' + fn_attr_name)
+    obj.writer = ContextWriter(ctx)
+    obj.conf = ctx.getJobConf()
+    spec = inspect.getargspec(user_fn)
+    if spec.varargs or len(spec.args) not in (3, 4):
+        raise ValueError(user_fn +
+           ' must take parameters key, value, writer, and optionally config)')
+    if len(spec.args) == 3:
+        setattr(obj, fn_attr_name, obj.without_conf)
+    elif len(spec.args) == 4:
+        setattr(obj, fn_attr_name, obj.with_conf)
+    else:
+        raise RuntimeError(
+            'Unexpected number of %(map_fn)s arguments ' + len(spec.args))
 
 
 class PydoopScriptMapper(pydoop.pipes.Mapper):
-  def __init__(self, ctx):
-    super(type(self), self).__init__(ctx)
-    setup_script_object(self, 'map', %(module)s.%(map_fn)s, ctx)
+    def __init__(self, ctx):
+        super(type(self), self).__init__(ctx)
+        setup_script_object(self, 'map', %(module)s.%(map_fn)s, ctx)
 
-  def without_conf(self, ctx):
-    # old style map function, without the conf parameter
-    writer = ContextWriter(ctx)
-    %(module)s.%(map_fn)s(ctx.getInputKey(), ctx.getInputValue(), writer)
+    def without_conf(self, ctx):
+        # old style map function, without the conf parameter
+        writer = ContextWriter(ctx)
+        %(module)s.%(map_fn)s(ctx.getInputKey(), ctx.getInputValue(), writer)
 
-  def with_conf(self, ctx):
-    # new style map function, without the conf parameter
-    writer = ContextWriter(ctx)
-    %(module)s.%(map_fn)s(ctx.getInputKey(), ctx.getInputValue(),
-                          writer, self.conf)
+    def with_conf(self, ctx):
+        # new style map function, without the conf parameter
+        writer = ContextWriter(ctx)
+        %(module)s.%(map_fn)s(ctx.getInputKey(), ctx.getInputValue(),
+                              writer, self.conf)
 
-  def map(self, ctx):
-    pass
+    def map(self, ctx):
+        pass
 
 
 class PydoopScriptReducer(pydoop.pipes.Reducer):
 
-  def __init__(self, ctx):
-    super(type(self), self).__init__(ctx)
-    setup_script_object(self, 'reduce', %(module)s.%(reduce_fn)s, ctx)
+    def __init__(self, ctx):
+        super(type(self), self).__init__(ctx)
+        setup_script_object(self, 'reduce', %(module)s.%(reduce_fn)s, ctx)
 
-  @staticmethod
-  def iter(ctx):
-    while ctx.nextValue():
-      yield ctx.getInputValue()
+    @staticmethod
+    def iter(ctx):
+        while ctx.nextValue():
+            yield ctx.getInputValue()
 
-  def without_conf(self, ctx):
-    key = ctx.getInputKey()
-    writer = ContextWriter(ctx)
-    %(module)s.%(reduce_fn)s(key, PydoopScriptReducer.iter(ctx), writer)
+    def without_conf(self, ctx):
+        key = ctx.getInputKey()
+        writer = ContextWriter(ctx)
+        %(module)s.%(reduce_fn)s(key, PydoopScriptReducer.iter(ctx), writer)
 
-  def with_conf(self, ctx):
-    key = ctx.getInputKey()
-    writer = ContextWriter(ctx)
-    %(module)s.%(reduce_fn)s(key, PydoopScriptReducer.iter(ctx),
-                             writer, self.conf)
+    def with_conf(self, ctx):
+        key = ctx.getInputKey()
+        writer = ContextWriter(ctx)
+        %(module)s.%(reduce_fn)s(key, PydoopScriptReducer.iter(ctx),
+                                 writer, self.conf)
 
-  def reduce(self, ctx):
-    pass
+    def reduce(self, ctx):
+        pass
 
 
 class PydoopScriptCombiner(pydoop.pipes.Combiner):
 
-  def __init__(self, ctx):
-    super(type(self), self).__init__(ctx)
-    setup_script_object(self, 'reduce', %(module)s.%(combine_fn)s, ctx)
+    def __init__(self, ctx):
+        super(type(self), self).__init__(ctx)
+        setup_script_object(self, 'reduce', %(module)s.%(combine_fn)s, ctx)
 
-  @staticmethod
-  def iter(ctx):
-    while ctx.nextValue():
-      yield ctx.getInputValue()
+    @staticmethod
+    def iter(ctx):
+        while ctx.nextValue():
+            yield ctx.getInputValue()
 
-  def without_conf(self, ctx):
-    key = ctx.getInputKey()
-    writer = ContextWriter(ctx)
-    %(module)s.%(combine_fn)s(key, PydoopScriptCombiner.iter(ctx), writer)
+    def without_conf(self, ctx):
+        key = ctx.getInputKey()
+        writer = ContextWriter(ctx)
+        %(module)s.%(combine_fn)s(key, PydoopScriptCombiner.iter(ctx), writer)
 
-  def with_conf(self, ctx):
-    key = ctx.getInputKey()
-    writer = ContextWriter(ctx)
-    %(module)s.%(combine_fn)s(key, PydoopScriptReducer.iter(ctx),
-                              writer, self.conf)
+    def with_conf(self, ctx):
+        key = ctx.getInputKey()
+        writer = ContextWriter(ctx)
+        %(module)s.%(combine_fn)s(key, PydoopScriptReducer.iter(ctx),
+                                  writer, self.conf)
 
-  def reduce(self, ctx):
-    pass
+    def reduce(self, ctx):
+        pass
 
 
 def main():


### PR DESCRIPTION
Changes the script template to use the new `pydoop.mapreduce.pipes` API (#245) and `string.template` (#244) for templating. Also, the generated code is now checked with flake8.