### PR TITLE
Fixes for file objects

### DIFF
--- a/pydoop/hdfs/file.py
+++ b/pydoop/hdfs/file.py
@@ -22,7 +22,7 @@ pydoop.hdfs.file -- HDFS File Objects
 """
 
 import os
-from io import FileIO, UnsupportedOperation
+import io
 import codecs
 
 from pydoop.hdfs import common
@@ -335,7 +335,7 @@ class hdfs_file(object):
         """
         _complain_ifclosed(self.closed)
         if not self.writable():
-            raise UnsupportedOperation("write")
+            raise io.UnsupportedOperation("write")
         if self.__encoding:
             self.f.write(data.encode(self.__encoding, self.__errors))
             return len(data)
@@ -362,7 +362,7 @@ class hdfs_file(object):
         return self.f.flush()
 
 
-class local_file(FileIO):
+class local_file(io.FileIO):
     """\
     Support class to handle local files.
 
@@ -377,7 +377,6 @@ class local_file(FileIO):
         name = os.path.abspath(name)
         super(local_file, self).__init__(name, mode_obj.value)
         self.__fs = fs
-        self.__name = name
         self.__size = os.fstat(super(local_file, self).fileno()).st_size
         self.f = self
         self.chunk_size = 0
@@ -440,3 +439,12 @@ class local_file(FileIO):
 
     def write_chunk(self, chunk):
         return self.write(chunk)
+
+
+class TextIOWrapper(io.TextIOWrapper):
+
+    def __getattr__(self, name):
+        a = getattr(self.buffer.raw, name)
+        if name == "mode":
+            a = "%st" % common.Mode(a).value[0]
+        return a

--- a/pydoop/hdfs/file.py
+++ b/pydoop/hdfs/file.py
@@ -444,7 +444,16 @@ class local_file(io.FileIO):
 class TextIOWrapper(io.TextIOWrapper):
 
     def __getattr__(self, name):
+        # there is no readinto method in text mode (strings are immutable)
+        if name.endswith("_chunk"):
+            raise AttributeError("%r object has no attribute %r" % (
+                self.__class__.__name__, name
+            ))
         a = getattr(self.buffer.raw, name)
         if name == "mode":
             a = "%st" % common.Mode(a).value[0]
         return a
+
+    def pread(self, position, length):
+        data = self.buffer.raw.pread(position, length)
+        return data.decode(self.encoding, self.errors)

--- a/pydoop/hdfs/fs.py
+++ b/pydoop/hdfs/fs.py
@@ -30,7 +30,7 @@ import io
 
 import pydoop
 from . import common
-from .file import hdfs_file, local_file, TextIOWrapper
+from .file import FileIO, hdfs_file, local_file, TextIOWrapper
 from .core import core_hdfs_fs
 
 # py3 compatibility
@@ -267,7 +267,8 @@ class hdfs(object):
                 fret = TextIOWrapper(cls(fret), encoding, errors)
             return fret
         f = self.fs.open_file(path, m.flags, buff_size, replication, blocksize)
-        fret = hdfs_file(f, self, path, m, readline_chunk_size)
+        cls = FileIO if m.text else hdfs_file
+        fret = cls(f, self, path, m, readline_chunk_size)
         if m.flags == os.O_RDONLY:
             fret.seek(0)
         return fret

--- a/pydoop/hdfs/fs.py
+++ b/pydoop/hdfs/fs.py
@@ -30,7 +30,7 @@ import io
 
 import pydoop
 from . import common
-from .file import hdfs_file, local_file
+from .file import hdfs_file, local_file, TextIOWrapper
 from .core import core_hdfs_fs
 
 # py3 compatibility
@@ -264,7 +264,7 @@ class hdfs(object):
             fret = local_file(self, path, common.Mode(m.value[0]))
             if m.text:
                 cls = io.BufferedWriter if m.writable else io.BufferedReader
-                fret = io.TextIOWrapper(cls(fret), encoding, errors)
+                fret = TextIOWrapper(cls(fret), encoding, errors)
             return fret
         f = self.fs.open_file(path, m.flags, buff_size, replication, blocksize)
         fret = hdfs_file(f, self, path, m, readline_chunk_size)

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -22,6 +22,7 @@ import unittest
 import uuid
 import shutil
 import operator
+import array
 from ctypes import create_string_buffer
 
 import pydoop.hdfs as hdfs
@@ -241,7 +242,9 @@ class TestCommon(unittest.TestCase):
                                  content[:bytes_read])
 
     def read_chunk(self):
-        for factory in bytearray, create_string_buffer:
+        def array_by_len(length):
+            return array.array("b", b"\x00" * length)
+        for factory in bytearray, create_string_buffer, array_by_len:
             self.__read_chunk(factory)
 
     def write(self):

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -536,12 +536,20 @@ class TestCommon(unittest.TestCase):
         data = text.encode("utf-8")
         with self.fs.open_file(t_path, "wt") as fo:
             chars_written = fo.write(text)
+            with self.assertRaises(AttributeError):
+                fo.write_chunk(u"foo")
         with self.fs.open_file(b_path, "w") as fo:
             bytes_written = fo.write(data)
         self.assertEqual(chars_written, len(text))
         self.assertEqual(bytes_written, len(data))
         with self.fs.open_file(t_path, "rt") as f:
             self.assertEqual(f.read(), text)
+            f.seek(2)
+            self.assertEqual(f.read(), text[2:])
+            self.assertEqual(f.pread(3, 4), text[3:7])
+            with self.assertRaises(AttributeError):
+                f.read_chunk("")
+                f.pread_chunk(1, "")
         with self.fs.open_file(b_path, "r") as f:
             self.assertEqual(f.read(), data)
 

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -186,17 +186,21 @@ class TestCommon(unittest.TestCase):
 
     def file_attrs(self):
         path = self._make_random_path()
-        with self.fs.open_file(path, os.O_WRONLY) as f:
-            self.assertTrue(f.name.endswith(path))
-            self.assertEqual(f.size, 0)
-            self.assertEqual(f.mode, "wb")
-            content = utils.make_random_data()
-            f.write(content)
-        self.assertEqual(f.size, len(content))
-        with self.fs.open_file(path) as f:
-            self.assertTrue(f.name.endswith(path))
+        content = utils.make_random_data()
+        for mode in "wb", "wt":
+            with self.fs.open_file(path, mode) as f:
+                self.assertTrue(f.name.endswith(path))
+                self.assertTrue(f.fs is self.fs)
+                self.assertEqual(f.size, 0)
+                self.assertEqual(f.mode, mode)
+                f.write(content if mode == "wb" else content.decode("utf-8"))
             self.assertEqual(f.size, len(content))
-            self.assertEqual(f.mode, "rb")
+        for mode in "rb", "rt":
+            with self.fs.open_file(path, mode) as f:
+                self.assertTrue(f.name.endswith(path))
+                self.assertTrue(f.fs is self.fs)
+                self.assertEqual(f.size, len(content))
+                self.assertEqual(f.mode, mode)
 
     def flush(self):
         path = self._make_random_path()

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -22,25 +22,12 @@ import unittest
 import uuid
 import shutil
 import operator
-
-try:
-    from itertools import izip as zip
-except ImportError as e:
-    pass
-
 from ctypes import create_string_buffer
 
 import pydoop.hdfs as hdfs
 import pydoop
 import pydoop.test_utils as utils
 from pydoop.utils.py3compat import _is_py3
-
-
-def _get_value(buf):
-    try:
-        return buf.value  # e.g., ctypes string buffer
-    except AttributeError:
-        return create_string_buffer(bytes(buf)).value  # e.g., bytearray
 
 
 class TestCommon(unittest.TestCase):
@@ -250,7 +237,8 @@ class TestCommon(unittest.TestCase):
                 chunk = chunk_factory(chunk_size)
                 bytes_read = f.read_chunk(chunk)
                 self.assertEqual(bytes_read, min(size, chunk_size))
-                self.assertEqual(_get_value(chunk), content[:bytes_read])
+                self.assertEqual(bytes(bytearray(chunk))[:bytes_read],
+                                 content[:bytes_read])
 
     def read_chunk(self):
         for factory in bytearray, create_string_buffer:
@@ -361,7 +349,6 @@ class TestCommon(unittest.TestCase):
 
     def list_directory(self):
         new_d = self._make_random_dir()
-
         self.assertEqual(self.fs.list_directory(new_d), [])
         paths = [self._make_random_file(where=new_d) for _ in range(3)]
         paths.sort(key=os.path.basename)


### PR DESCRIPTION
* Fixes #247 
* Uses `readinto` to re-implement the `*_chunk` variants of reading methods in local files without making extra copies
* Uses distinct classes for HDFS binary and text files, similarly to what Python does in `io`.

TODO: to get something more like `io`, "true" HDFS files should also be binary-only, with text I/O provided by a wrapper (can we reuse `TextIOWrapper`?).