### PR TITLE
Fix non-java output handling in submitter

### DIFF
--- a/examples/pydoop_submit/mr/map_only_java_writer.py
+++ b/examples/pydoop_submit/mr/map_only_java_writer.py
@@ -30,3 +30,7 @@ class Mapper(api.Mapper):
 
 def __main__():
     pipes.run_task(pipes.Factory(mapper_class=Mapper))
+
+
+if __name__ == "__main__":
+    __main__()

--- a/examples/pydoop_submit/mr/nosep.py
+++ b/examples/pydoop_submit/mr/nosep.py
@@ -31,3 +31,7 @@ class Mapper(api.Mapper):
 
 def __main__():
     pp.run_task(pp.Factory(Mapper, None))
+
+
+if __name__ == "__main__":
+    __main__()

--- a/examples/run_all
+++ b/examples/run_all
@@ -27,7 +27,7 @@ examples=(
     pydoop_submit
     self_contained
     sequence_file
-    simulator
+    # simulator  # excluded until issue #246 is fixed
     wordcount
 )
 some_failed=0

--- a/examples/wordcount/bin/wordcount_full.py
+++ b/examples/wordcount/bin/wordcount_full.py
@@ -22,7 +22,7 @@ import logging
 
 logging.basicConfig()
 LOGGER = logging.getLogger("WordCount")
-LOGGER.setLevel(logging.CRITICAL)
+LOGGER.setLevel(logging.INFO)
 
 import re
 from hashlib import md5
@@ -110,13 +110,11 @@ class Writer(api.RecordWriter):
         super(Writer, self).__init__(context)
         self.logger = LOGGER.getChild("Writer")
         jc = context.job_conf
-        part = jc.get_int("mapred.task.partition")
-        out_dir = jc["mapred.work.output.dir"]
-        outfn = "%s/part-%05d" % (out_dir, part)
+        outfn = context.get_default_work_file()
+        self.logger.info("writing to %s", outfn)
         hdfs_user = jc.get("pydoop.hdfs.user", None)
         self.file = hdfs.open(outfn, "wt", user=hdfs_user)
-        self.sep = jc.get("mapred.textoutputformat.separator", "\t")
-        self.eol = jc.get("mapred.textoutputformat.eol", "\n")
+        self.sep = jc.get("mapreduce.output.textoutputformat.separator", "\t")
 
     def close(self):
         self.logger.debug("closing open handles")
@@ -124,7 +122,7 @@ class Writer(api.RecordWriter):
         self.file.fs.close()
 
     def emit(self, key, value):
-        self.file.write(key + self.sep + str(value) + self.eol)
+        self.file.write(key + self.sep + str(value) + "\n")
 
 
 class Partitioner(api.Partitioner):

--- a/pydoop/mapreduce/pipes.py
+++ b/pydoop/mapreduce/pipes.py
@@ -518,7 +518,7 @@ class StreamRunner(object):
                 LOGGER.debug("Input (key, value) class: (%r, %r)",
                              ctx._input_key_class, ctx._input_value_class)
         reader = factory.create_record_reader(ctx)
-        if reader is None and piped_input is None:
+        if reader is None and not piped_input:
             raise api.PydoopError('RecordReader not defined')
         send_progress = reader is not None
         mapper = factory.create_mapper(ctx)

--- a/src/it/crs4/pydoop/mapreduce/pipes/Application.java
+++ b/src/it/crs4/pydoop/mapreduce/pipes/Application.java
@@ -56,11 +56,13 @@ import org.apache.hadoop.mapreduce.TaskInputOutputContext;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.TaskID;
 import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.hadoop.mapreduce.filecache.DistributedCache;
 import org.apache.hadoop.mapreduce.security.SecureShuffleUtils;
 import org.apache.hadoop.mapreduce.security.TokenCache;
 import org.apache.hadoop.mapreduce.security.token.JobTokenIdentifier;
 import org.apache.hadoop.mapreduce.security.token.JobTokenSecretManager;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.StringUtils;
@@ -90,6 +92,11 @@ class Application<K1 extends Writable, V1 extends Writable,
         throws IOException, InterruptedException {
 
         Configuration conf = context.getConfiguration();
+        OutputCommitter committer = context.getOutputCommitter();
+        if (committer instanceof FileOutputCommitter) {
+          conf.set(MRJobConfig.TASK_OUTPUT_DIR,
+                   ((FileOutputCommitter)committer).getWorkPath().toString());
+        }
         serverSocket = new ServerSocket(0);
         Map<String, String> env = new HashMap<String,String>();
         // add TMPDIR environment variable with the value of java.io.tmpdir

--- a/src/it/crs4/pydoop/mapreduce/pipes/PipesNonJavaOutputFormat.java
+++ b/src/it/crs4/pydoop/mapreduce/pipes/PipesNonJavaOutputFormat.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.crs4.pydoop.mapreduce.pipes;
+
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+
+/**
+ * Ignores all output, but otherwise behaves like FileOutputFormat
+ * (e.g., temp dir management).
+ */
+public class PipesNonJavaOutputFormat<K, V> extends FileOutputFormat<K, V> {
+
+  @Override
+  public RecordWriter<K, V> getRecordWriter(TaskAttemptContext context) {
+    return new RecordWriter<K, V>() {
+        public void write(K key, V value) { }
+        public void close(TaskAttemptContext context) { }
+    };
+  }
+
+}

--- a/src/it/crs4/pydoop/mapreduce/pipes/Submitter.java
+++ b/src/it/crs4/pydoop/mapreduce/pipes/Submitter.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat;
-import org.apache.hadoop.mapreduce.lib.output.NullOutputFormat;
 import org.apache.hadoop.mapreduce.lib.partition.HashPartitioner;
 import org.apache.hadoop.mapreduce.filecache.DistributedCache;
 import org.apache.hadoop.mapreduce.MRJobConfig;
@@ -347,7 +346,7 @@ public class Submitter extends Configured implements Tool {
     if (!getIsJavaReducer(conf)) {
       job.setReducerClass(PipesReducer.class);
       if (!getIsJavaRecordWriter(conf)) {
-        job.setOutputFormatClass(NullOutputFormat.class);
+        job.setOutputFormatClass(PipesNonJavaOutputFormat.class);
       }
     }
     String textClassname = Text.class.getName();

--- a/test/mapreduce/data/stream_data.py
+++ b/test/mapreduce/data/stream_data.py
@@ -50,8 +50,8 @@ STREAM_2_DATA = [
 STREAM_3_DATA = [
     (streams.START_MESSAGE, 0),
     (streams.SET_JOB_CONF,) + JOB_CONF,
+    (streams.RUN_MAP, 'input_split', 0, 1),
     (streams.SET_INPUT_TYPES, 'key_type', 'value_type'),
-    (streams.RUN_MAP, 'input_split', 0, 0),
     (streams.MAP_ITEM, 'key1', 'the blue fox jumps on the table'),
     (streams.MAP_ITEM, 'key1', 'a yellow fox turns around'),
     (streams.MAP_ITEM, 'key2', 'a blue yellow fox sits on the table'),
@@ -77,8 +77,8 @@ STREAM_4_DATA = [
 STREAM_5_DATA = [
     (streams.START_MESSAGE, 0),
     (streams.SET_JOB_CONF,) + JOB_CONF,
+    (streams.RUN_MAP, 'input_split', 0, 1),
     (streams.SET_INPUT_TYPES, 'key_type', 'value_type'),
-    (streams.RUN_MAP, 'input_split', 0, 0),
     (streams.MAP_ITEM, 'key1', 'the blue fox jumps on the table'),
     (streams.MAP_ITEM, 'key1', 'a yellow fox turns around'),
     (streams.MAP_ITEM, 'key2', 'a blue yellow fox sits on the table'),
@@ -88,8 +88,8 @@ STREAM_5_DATA = [
 STREAM_6_DATA = [
     (streams.START_MESSAGE, 0),
     (streams.SET_JOB_CONF,) + JOB_CONF,
+    (streams.RUN_MAP, 'input_split', 1, 1),
     (streams.SET_INPUT_TYPES, 'key_type', 'value_type'),
-    (streams.RUN_MAP, 'input_split', 1, 0),
     (streams.MAP_ITEM, 'key1', 'the blue fox jumps on the table'),
     (streams.MAP_ITEM, 'key1', 'a yellow fox turns around'),
     (streams.MAP_ITEM, 'key2', 'a blue yellow fox sits on the table'),


### PR DESCRIPTION
The main purpose of this PR is to fix a problem in our pipes submitter (`src/it/crs4/pydoop/mapreduce/pipes`). A bit of background:

 * We wrote our own porting of the pipes submitter to the `(org.apache.hadoop.)mapreduce` API, while the one that ships with Hadoop (called via `hadoop pipes`) uses the `(org.apache.hadoop.)mapred` API. The former allows to use Java components (e.g., input formats) written with the `mapreduce` API, including Avro-based ones. Our submitter is tested, together with the Python pipes code, by examples under `examples/pydoop_submit`.

 * The Python pipes code also works with Hadoop's standard `mapred` submitter. This is currently checked via the `wordcount` examples.

 * Hadoop has a *speculative execution* feature to mitigate cluster underutilization at the end of a job, when a few stragglers typically use only a fraction of the available capacity. In this case, additional instances of currently running tasks can be executed in parallel using any free resources (once an instance completes successfully, all the others are killed). To avoid problems due to multiple instances of the same task trying to access the same output file, when the output format class is a subclass of `FileOutputFormat` (in particular, with the default `TextOutputFormat`), Hadoop automatically creates a unique temporary "work" directory for each task attempt. Supposing the final output directory for the job (`mapreduce.output.fileoutputformat.outputdir`) is `hdfs://localhost:9000/foo/output`, the work dir (`mapreduce.task.output.dir`) will look like `hdfs://localhost:9000/foo/output/_temporary/1/_temporary/attempt_1515666858080_0001_m_000000_0/`. Another utility (`FileOutputFormat.getUniqueFile`) provides a standard scheme to get an output file for the current task based on its type and partition number (e.g., `part-r-00001`). On successful completion of a task attempt, files in the corresponding work dir are moved to the final output dir; if the attempt is not successful, on the other hand, they are deleted.

 * When the user opts to use a non-Java record writer, the original submitter sets the output format to `NullOutputFormat`, since the Java side of things is supposed to ignore all output. Without this PR, our submitter also performs this setting.

The problem is that with the `mapreduce` API (but not with the `mapred` one) **all** things related to output handling are delegated to the output format, including the creation of work directories and the handling of successful and unsuccessful tasks, which is therefore **unavailable** with `NullOutputFormat` (or any output format that's not derived from `FileOutputFormat`). This PR adds a new `PipesNonJavaOutputFormat` class that leaves the output alone (in particular, it does not create any files), but behaves like `FileOutputFormat` in other respects, including work dir creation. Changes in `Application.java` ensure that `mapreduce.task.output.dir` is correctly set to the work dir path when it's present, so that the non-java part can retrieve its value (with the `mapreduce` API it's set to the final output dir, probably due to an unnoticed Hadoop bug).

On the Python side, this PR adds new context methods that encapsulate the code needed to get the work dir and default filename (names mirror those of the corresponding Java methods). Examples that use a Python record writer have been updated to use them.

Other things fixed while testing:

* Modified `pydoop_submit` examples so that they can be run with the standard submitter, which does not use the `__main__` convention.

* Fixed piped input detection.

* Fixed out-of-order commands in framework test streams.

**Testing:**

Triggering the bug is not easy with a toy pseudocluster. In a cluster with a reasonable number of slots, without this PR, when running (with `pydoop submit`) any application that uses a Python record writer, HDFS errors should start popping out after the job has been allowed to run for a while. With this PR, those errors should stop appearing. Alternatively, check that the value of `mapreduce.task.output.dir` seen within the Python record writer has a `_temporary/[...]` part.