### PR TITLE
New debugging options for submit

### DIFF
--- a/examples/pydoop_submit/run
+++ b/examples/pydoop_submit/run
@@ -9,3 +9,5 @@ this_dir=$(cd -P -- "$(dirname -- "${this}")" && pwd -P)
 for s in map_only_java_writer map_only_python_writer nosep wordcount_full wordcount_minimal; do
     bash "${this_dir}"/run_submit.sh ${s}
 done
+
+bash "${this_dir}"/run_submit.sh -p wordcount_minimal_pstats wordcount_minimal

--- a/examples/pydoop_submit/run_submit.sh
+++ b/examples/pydoop_submit/run_submit.sh
@@ -34,6 +34,7 @@ while getopts ":p:" opt; do
     case ${opt} in
     p )
 	OPTS+=( "--pstats-dir" "${OPTARG}" )
+	OPTS+=( "--pstats-fmt" "_test_%s_%05d_%s" )
 	;;
     \? )
 	echo "Invalid option: -${OPTARG}" >&2

--- a/examples/pydoop_submit/run_submit.sh
+++ b/examples/pydoop_submit/run_submit.sh
@@ -24,9 +24,32 @@ this="${BASH_SOURCE-$0}"
 this_dir=$(cd -P -- "$(dirname -- "${this}")" && pwd -P)
 . "${this_dir}/../config.sh"
 
+OPTS=(
+    "-D" "mapreduce.task.timeout=10000"
+    "-D" "mapred.map.tasks=2"
+    "--python-program" "${PYTHON}"
+)
+
+while getopts ":p:" opt; do
+    case ${opt} in
+    p )
+	OPTS+=( "--pstats-dir" "${OPTARG}" )
+	;;
+    \? )
+	echo "Invalid option: -${OPTARG}" >&2
+	exit 1
+	;;
+    : )
+	echo "Option -${OPTARG} requires an argument" >&2
+	exit 1
+	;;
+    esac
+done
+shift $((${OPTIND} - 1))
+
 nargs=1
 if [ $# -ne ${nargs} ]; then
-    die "Usage: $0 module_name"
+    die "Usage: $0 [-p PSTATS_DIR] MODULE_NAME"
 fi
 MODULE=$1
 
@@ -35,12 +58,7 @@ INPUT=${MODULE}_input
 OUTPUT=${MODULE}_output
 RESULTS=results.txt
 
-OPTS=(
-    "-D" "mapreduce.task.timeout=10000"
-    "-D" "mapred.map.tasks=2"
-    "--python-program" "${PYTHON}"
-    "--job-name" "${JOBNAME}"
-)
+OPTS+=( "--job-name" "${JOBNAME}" )
 case ${MODULE} in
     wordcount_minimal )
 	DATA="${this_dir}"/../input/alice.txt

--- a/pydoop/app/script.py
+++ b/pydoop/app/script.py
@@ -110,6 +110,8 @@ class PydoopScript(object):
                           args.kv_separator)]
         args.avro_input = None
         args.avro_output = None
+        args.keep_wd = False
+        args.pstats_dir = None
 
         # despicable hack...
         properties = dict(args.D or [])

--- a/pydoop/app/script.py
+++ b/pydoop/app/script.py
@@ -112,6 +112,7 @@ class PydoopScript(object):
         args.avro_output = None
         args.keep_wd = False
         args.pstats_dir = None
+        args.pstats_fmt = None
 
         # despicable hack...
         properties = dict(args.D or [])

--- a/pydoop/app/submit.py
+++ b/pydoop/app/submit.py
@@ -33,6 +33,7 @@ import pydoop.hdfs as hdfs
 import pydoop.hadut as hadut
 import pydoop.utils as utils
 import pydoop.utils.conversion_tables as conv_tables
+from pydoop.mapreduce.pipes import PSTATS_DIR
 
 from .argparse_types import kv_pair, a_file_that_can_be_read
 from .argparse_types import a_comma_separated_list, a_hdfs_file
@@ -219,6 +220,9 @@ class PydoopSubmitter(object):
         for var, value in self.requested_env.items():
             env[var] = value
 
+        if self.args.pstats_dir:
+            env[PSTATS_DIR] = self.args.pstats_dir
+
         executable = self.args.python_program
         if self.args.python_zip:
             env['PYTHONPATH'] = ':'.join([
@@ -374,7 +378,8 @@ class PydoopSubmitter(object):
                      logger=self.logger, keep_streams=False)
             self.logger.info("Done")
         finally:
-            self.__clean_wd()
+            if not self.args.keep_wd:
+                self.__clean_wd()
 
     def fake_run_class(self, *args, **kwargs):
         kwargs['logger'].info("Fake run class")
@@ -534,6 +539,13 @@ def add_parser_arguments(parser):
     parser.add_argument(
         '--avro-output', metavar='k|v|kv', choices=AVRO_IO_CHOICES,
         help="Avro output mode (key, value or both)",
+    )
+    parser.add_argument(
+        '--pstats-dir', metavar="HDFS_DIR", type=str,
+        help="Profile each task and store stats in this dir"
+    )
+    parser.add_argument(
+        '--keep-wd', action='store_true', help="Don't remove the work dir"
     )
 
 

--- a/pydoop/app/submit.py
+++ b/pydoop/app/submit.py
@@ -33,7 +33,7 @@ import pydoop.hdfs as hdfs
 import pydoop.hadut as hadut
 import pydoop.utils as utils
 import pydoop.utils.conversion_tables as conv_tables
-from pydoop.mapreduce.pipes import PSTATS_DIR
+from pydoop.mapreduce.pipes import PSTATS_DIR, PSTATS_FMT
 
 from .argparse_types import kv_pair, a_file_that_can_be_read
 from .argparse_types import a_comma_separated_list, a_hdfs_file
@@ -222,6 +222,8 @@ class PydoopSubmitter(object):
 
         if self.args.pstats_dir:
             env[PSTATS_DIR] = self.args.pstats_dir
+            if self.args.pstats_fmt:
+                env[PSTATS_FMT] = self.args.pstats_fmt
 
         executable = self.args.python_program
         if self.args.python_zip:
@@ -543,6 +545,10 @@ def add_parser_arguments(parser):
     parser.add_argument(
         '--pstats-dir', metavar="HDFS_DIR", type=str,
         help="Profile each task and store stats in this dir"
+    )
+    parser.add_argument(
+        '--pstats-fmt', metavar="STRING", type=str,
+        help="pstats filename pattern (expert use only)"
     )
     parser.add_argument(
         '--keep-wd', action='store_true', help="Don't remove the work dir"

--- a/pydoop/mapreduce/pipes.py
+++ b/pydoop/mapreduce/pipes.py
@@ -52,6 +52,8 @@ LOGGER = logging.getLogger('pipes')
 LOGGER.setLevel(logging.CRITICAL)
 
 PSTATS_DIR = "PYDOOP_PSTATS_DIR"
+PSTATS_FMT = "PYDOOP_PSTATS_FMT"
+DEFAULT_PSTATS_FMT = "%s_%05d_%s"  # task_type, task_id, random suffix
 if os.getenv(PSTATS_DIR):
     import tempfile
     import cProfile
@@ -608,13 +610,14 @@ def run_task(factory, port=None, istream=None, ostream=None,
     stream_runner = StreamRunner(factory, context, connections.cmd_stream)
     pstats_dir = os.getenv(PSTATS_DIR)
     if pstats_dir:
+        pstats_fmt = os.getenv(PSTATS_FMT, DEFAULT_PSTATS_FMT)
         hdfs.mkdir(pstats_dir)
         fd, pstats_fn = tempfile.mkstemp(suffix=".pstats")
         os.close(fd)
         cProfile.runctx("stream_runner.run()",
                         {"stream_runner": stream_runner}, globals(),
                         filename=pstats_fn)
-        name = '_%s_%05d_%s' % (
+        name = pstats_fmt % (
             "r" if context.is_reducer() else "m",
             context.get_task_partition(), os.path.basename(pstats_fn)
         )

--- a/pydoop/mapreduce/pipes.py
+++ b/pydoop/mapreduce/pipes.py
@@ -23,12 +23,9 @@ import time
 import numbers
 import struct
 import types
-import tempfile
-import cProfile
 
 from copy import deepcopy
 
-import pydoop.hdfs as hdfs
 from pydoop import hadoop_version_info
 from pydoop.utils.serialize import (
     deserialize_text,
@@ -55,6 +52,10 @@ LOGGER = logging.getLogger('pipes')
 LOGGER.setLevel(logging.CRITICAL)
 
 PSTATS_DIR = "PYDOOP_PSTATS_DIR"
+if os.getenv(PSTATS_DIR):
+    import tempfile
+    import cProfile
+    import pydoop.hdfs as hdfs
 DEFAULT_IO_SORT_MB = 100
 
 _PORT_KEYS = frozenset([


### PR DESCRIPTION
Adds two debugging args to `pydoop submit`:

* `keep_wd`, to turn off auto-deletion of our own HDFS working dir
* `pstats_dir`, to enable individual task profiling. Results are stored in the given HDFS directory.

Generated pstats files look like this: `_m_00000_tmpmhm9coxt.pstats`, where `m` is the task type (map), `00000` is the partition number and the random part is carried over from `tempfile.mkstemp` (this avoids clashes between different task attempts, which have the same partition number). Files begin with an underscore so that the user can choose to store them in the output dir without affecting subsequent processing.

**On the other hand, if we want to allow MapReduce processing of the pstats file themselves, we should probably remove the underscore (and implicitly discourage their storage in the job's output dir). We should probably settle this before merging.**