### PR TITLE
Performance improvements: HDFS write

### DIFF
--- a/pydoop/hdfs/file.py
+++ b/pydoop/hdfs/file.py
@@ -304,8 +304,6 @@ class FileIO(object):
         :return: the number of bytes written
         """
         _complain_ifclosed(self.closed)
-        if not self.writable():
-            raise io.UnsupportedOperation("write")
         if self.__encoding:
             self.f.write(data.encode(self.__encoding, self.__errors))
             return len(data)

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -227,7 +227,10 @@ class TestCommon(unittest.TestCase):
         with self.fs.open_file(path) as f:
             self.assertEqual(f.read(3), content[:3])
             self.assertEqual(f.read(3), content[3:6])
-            self.assertRaises(IOError, f.write, content)
+            if not _is_py3 and not self.fs.host:
+                self.assertRaises(ValueError, f.write, content)
+            else:
+                self.assertRaises(IOError, f.write, content)
 
     def __read_chunk(self, chunk_factory):
         content = utils.make_random_data()

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -227,7 +227,7 @@ class TestCommon(unittest.TestCase):
         with self.fs.open_file(path) as f:
             self.assertEqual(f.read(3), content[:3])
             self.assertEqual(f.read(3), content[3:6])
-            self.assertRaisesExternal(ValueError, f.write, content)
+            self.assertRaises(IOError, f.write, content)
 
     def __read_chunk(self, chunk_factory):
         content = utils.make_random_data()

--- a/test/hdfs/test_hdfs.py
+++ b/test/hdfs/test_hdfs.py
@@ -321,7 +321,7 @@ class TestHDFS(unittest.TestCase):
             def count(self):
                 return self.counter.count
 
-        some_data = "a" * (5 * 1024 * 1024)  # 5 MB
+        some_data = b"a" * (5 * 1024 * 1024)  # 5 MB
         counter = BusyContext()
 
         ###########################

--- a/test/hdfs/test_hdfs_fs.py
+++ b/test/hdfs/test_hdfs_fs.py
@@ -192,7 +192,7 @@ class TestHDFS(TestCommon):
             blocksize = 1048576
             kwargs['blocksize'] = blocksize
         N = 4
-        content = "x" * blocksize * N
+        content = b"x" * blocksize * N
         path = self._make_random_file(content=content, **kwargs)
         start = 0
         for i in range(N):

--- a/test/hdfs/test_path.py
+++ b/test/hdfs/test_path.py
@@ -341,7 +341,7 @@ class TestStat(unittest.TestCase):
         fn = '/user/%s/%s' % (DEFAULT_USER, bn)
         fs = hdfs.hdfs("default", 0)
         p = "hdfs://%s:%s%s" % (fs.host, fs.port, fn)
-        with fs.open_file(fn, 'w') as fo:
+        with fs.open_file(fn, 'wt') as fo:
             fo.write(make_random_str())
         info = fs.get_path_info(fn)
         fs.close()


### PR DESCRIPTION
* Removes the Python-level writable check. This is both expensive and redundant, since we already have that check at a lower level.
* Removes auto-conversion of unicode objects: after #256, this is either wrong or redundant depending on how the file was opened (text vs binary)

Everything else is code cleanup and/or making sure that exceptions match what the Python user would expect.