### PR TITLE
Performance improvements: binary send

### DIFF
--- a/pydoop/avrolib.py
+++ b/pydoop/avrolib.py
@@ -150,8 +150,7 @@ class AvroContext(pp.TaskContext):
             for mode, record in iteritems(out_kv):
                 serializer = self.__serializers.get(mode)
                 if serializer is not None:
-                    with self.timer.time_block('avro serialization'):
-                        out_kv[mode] = serializer.serialize(record)
+                    out_kv[mode] = serializer.serialize(record)
         return out_kv['K'], out_kv['V']
 
     # move to super?

--- a/pydoop/mapreduce/binary_streams.py
+++ b/pydoop/mapreduce/binary_streams.py
@@ -38,16 +38,13 @@ class BinaryWriter(StreamWriter):
         self.original_stream = stream
 
     def send(self, cmd, *args):
-        self.logger.debug('request to write %r, %r', cmd, args)
         typecodes = RULES[cmd] if cmd != self.SET_JOB_CONF else 's' * len(args)
         args = self.__to_bytes(args, typecodes)
         if cmd == self.SET_JOB_CONF:
             args = (args,)
-        self.logger.debug('writing (%r, %r)', cmd, args)
         self.stream.write((cmd, args))
 
     def __to_bytes(self, args, typecodes):
-        assert len(args) == len(typecodes)
         out_args = []
         for a, t in zip(args, typecodes):
             if t == "s" and not isinstance(a, (bytes, bytearray)):

--- a/pydoop/mapreduce/connections.py
+++ b/pydoop/mapreduce/connections.py
@@ -44,11 +44,12 @@ class Connections(object):
         self.up_link.close()
 
 
-def open_playback_connections(cmd_file, out_file):
+def open_playback_connections(cmd_file, out_file, auto_serialize=True):
     in_stream = open(cmd_file, 'rb')
     out_stream = open(out_file, 'wb')
-    return Connections(BinaryDownStreamAdapter(in_stream),
-                       BinaryUpStreamAdapter(out_stream))
+    cmd_stream = BinaryDownStreamAdapter(in_stream)
+    up_link = BinaryUpStreamAdapter(out_stream, auto_serialize=auto_serialize)
+    return Connections(cmd_stream, up_link)
 
 
 def open_file_connections(istream=sys.stdin, ostream=sys.stdout):
@@ -69,10 +70,11 @@ class NetworkConnections(Connections):
         self.socket.close()
 
 
-def open_network_connections(port):
+def open_network_connections(port, auto_serialize=True):
     s = socket.socket()
     s.connect(('localhost', port))
     in_stream = os.fdopen(os.dup(s.fileno()), 'r', BUF_SIZE)
     out_stream = os.fdopen(os.dup(s.fileno()), 'w', BUF_SIZE)
-    return NetworkConnections(BinaryDownStreamAdapter(in_stream),
-                              BinaryUpStreamAdapter(out_stream), s, port)
+    cmd_stream = BinaryDownStreamAdapter(in_stream)
+    up_link = BinaryUpStreamAdapter(out_stream, auto_serialize=auto_serialize)
+    return NetworkConnections(cmd_stream, up_link, s, port)


### PR DESCRIPTION
* Removes logs and asserts. In such a time-critical section (it's called from within the app's inner loop), these are quite relevant
* Makes automatic conversion of arguments to bytes optional. This allows applications that exchange bytes to get an additional performance boost by cutting out redundant checks

Also removes all infrastructure timers. Since they trigger counter updates, these are also very expensive, and should not be needed anymore after #260