### PR TITLE
More terasort tweaks

### DIFF
--- a/examples/pseudo_terasort/Makefile
+++ b/examples/pseudo_terasort/Makefile
@@ -23,11 +23,11 @@ SAMPLED_RECORDS ?= 10000
 NUM_MAPS ?= 2
 NUM_REDUCERS ?= 2
 PYINPUTFORMAT_JAR=pydoop-input-formats.jar
-LOGLEVEL=INFO
-GENRECORDS_INPUT=genrecords_input
-GENRECORDS_OUTPUT=genrecords_output
-SORTRECORDS_OUTPUT=sortrecords_output
-CHECKRECORDS_OUTPUT=checkrecords_output
+LOGLEVEL ?= INFO
+GENRECORDS_INPUT ?= genrecords_input
+GENRECORDS_OUTPUT ?= genrecords_output
+SORTRECORDS_OUTPUT ?= sortrecords_output
+CHECKRECORDS_OUTPUT ?= checkrecords_output
 
 pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
 

--- a/examples/pseudo_terasort/it/crs4/pydoop/examples/pterasort/RangeInputFormat.java
+++ b/examples/pseudo_terasort/it/crs4/pydoop/examples/pterasort/RangeInputFormat.java
@@ -1,20 +1,20 @@
-// BEGIN_COPYRIGHT
-// 
-// Copyright 2009-2016 CRS4.
-// 
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not
-// use this file except in compliance with the License. You may obtain a copy
-// of the License at
-// 
-//   http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
-// 
-// END_COPYRIGHT
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package it.crs4.pydoop.examples.pterasort;
 
@@ -25,11 +25,8 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
-import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.io.WritableUtils;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.Job;
@@ -41,43 +38,44 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
 /**
  * An input format that assigns ranges of longs to each mapper.
+ * This is the same input format used in Hadoop's teragen example,
+ * but made externally available as a public class.
  */
-public class RangeInputFormat 
-    extends InputFormat<LongWritable, NullWritable> {
-    private static final Log LOG = LogFactory.getLog(RangeInputFormat.class);
-    
-    public RecordReader<LongWritable, NullWritable> 
-        createRecordReader(InputSplit split, TaskAttemptContext context) 
-        throws IOException {
-        return new RangeRecordReader();
-    }
+public class RangeInputFormat extends InputFormat<LongWritable, NullWritable> {
 
-    /**
-     * Create the desired number of splits, dividing the number of rows
-     * between the mappers.
-     */
-    public List<InputSplit> getSplits(JobContext job) {
-        long totalRows = getNumberOfRows(job);
-        int numSplits = job.getConfiguration().getInt(MRJobConfig.NUM_MAPS, 1);
-        LOG.info("Generating " + totalRows + " using " + numSplits);
-        List<InputSplit> splits = new ArrayList<InputSplit>();
-        long currentRow = 0;
-        for(int split = 0; split < numSplits; ++split) {
-            long goal = 
-                (long) Math.ceil(totalRows * (double)(split + 1) / numSplits);
-            splits.add(new RangeInputSplit(currentRow, goal - currentRow));
-            currentRow = goal;
-        }
-        return splits;
-    }
+  private static final Log LOG = LogFactory.getLog(RangeInputFormat.class);
 
-    static long getNumberOfRows(JobContext job) {
-        return job.getConfiguration().getLong("mapreduce.pterasort.num-rows", 0L);
+  public static final String NUM_ROWS = "mapreduce.pterasort.num-rows";
+
+  public RecordReader<LongWritable, NullWritable>
+      createRecordReader(InputSplit split, TaskAttemptContext context)
+      throws IOException {
+    return new RangeRecordReader();
+  }
+
+  /**
+   * Create the desired number of splits, dividing the number of rows
+   * between the mappers.
+   */
+  public List<InputSplit> getSplits(JobContext job) {
+    long totalRows = getNumberOfRows(job);
+    int numSplits = job.getConfiguration().getInt(MRJobConfig.NUM_MAPS, 1);
+    LOG.info("Generating " + totalRows + " using " + numSplits);
+    List<InputSplit> splits = new ArrayList<InputSplit>();
+    long currentRow = 0;
+    for (int s = 0; s < numSplits; ++s) {
+      long goal = (long)Math.ceil(totalRows * (double)(s + 1) / numSplits);
+      splits.add(new RangeInputSplit(currentRow, goal - currentRow));
+      currentRow = goal;
     }
-  
-    static void setNumberOfRows(Job job, long numRows) {
-        job.getConfiguration().setLong("mapreduce.pterasort.num-rows", numRows);
-    }
+    return splits;
+  }
+
+  static long getNumberOfRows(JobContext job) {
+    return job.getConfiguration().getLong(NUM_ROWS, 0L);
+  }
+
+  static void setNumberOfRows(Job job, long numRows) {
+    job.getConfiguration().setLong(NUM_ROWS, numRows);
+  }
 }
-
-

--- a/examples/pseudo_terasort/it/crs4/pydoop/examples/pterasort/RangeInputSplit.java
+++ b/examples/pseudo_terasort/it/crs4/pydoop/examples/pterasort/RangeInputSplit.java
@@ -1,80 +1,78 @@
-// BEGIN_COPYRIGHT
-// 
-// Copyright 2009-2016 CRS4.
-// 
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not
-// use this file except in compliance with the License. You may obtain a copy
-// of the License at
-// 
-//   http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
-// 
-// END_COPYRIGHT
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package it.crs4.pydoop.examples.pterasort;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableUtils;
-// import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 
 
-
 /**
- * An input split consisting of a range on numbers.
+ * An input split consisting of a range of numbers.
+ * This mimics the original RangeInputSplit, but we have to extend
+ * FileSplit to make pipes happy.
  */
-//public class RangeInputSplit extends InputSplit implements Writable {
-// FIXME: InputSplit is not Writable, see it.crs4.mapreduce.pipes.PipesMapper
-// FIXME: still, it is ugly.
 public class RangeInputSplit extends FileSplit {
-    long firstRow;
-    long rowCount;
 
-    public RangeInputSplit() { }
+  long firstRow;
+  long rowCount;
 
-    public RangeInputSplit(long offset, long length) {
-        firstRow = offset;
-        rowCount = length;
-    }
+  public RangeInputSplit() {}
 
-    /** The file containing this split's data. */
-    @Override
-    // FIXME: HACK!
-    public Path getPath() { return new Path("file:///dev/null"); } 
-  
-    /** The position of the first byte in the 'file' to process. */
-    @Override    
-    public long getStart() { return 0; }
-  
-    /** The number of bytes in the 'file' to process. */
-    @Override
-    public long getLength() /* throws IOException */ {
-        return 0;
-    }
+  public RangeInputSplit(long offset, long length) {
+    firstRow = offset;
+    rowCount = length;
+  }
 
-    @Override
-    public String[] getLocations() /* throws IOException */ {
-        return new String[]{};
-    }
+  @Override
+  public Path getPath() {
+    return new Path("file:///dev/null");  // not a real FileSplit
+  }
 
-    @Override
-    public void readFields(DataInput in) throws IOException {
-        firstRow = WritableUtils.readVLong(in);
-        rowCount = WritableUtils.readVLong(in);
-    }
+  @Override
+  public long getStart() {
+    return 0;
+  }
 
-    @Override
-    public void write(DataOutput out) throws IOException {
-        WritableUtils.writeVLong(out, firstRow);
-        WritableUtils.writeVLong(out, rowCount);
-    }
+  @Override
+  public long getLength() {
+    return 0;
+  }
+
+  @Override
+  public String[] getLocations() {
+    return new String[]{};
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    firstRow = WritableUtils.readVLong(in);
+    rowCount = WritableUtils.readVLong(in);
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    WritableUtils.writeVLong(out, firstRow);
+    WritableUtils.writeVLong(out, rowCount);
+  }
+
 }

--- a/examples/pseudo_terasort/it/crs4/pydoop/examples/pterasort/RangeRecordReader.java
+++ b/examples/pseudo_terasort/it/crs4/pydoop/examples/pterasort/RangeRecordReader.java
@@ -1,20 +1,20 @@
-// BEGIN_COPYRIGHT
-// 
-// Copyright 2009-2016 CRS4.
-// 
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not
-// use this file except in compliance with the License. You may obtain a copy
-// of the License at
-// 
-//   http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
-// 
-// END_COPYRIGHT
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package it.crs4.pydoop.examples.pterasort;
 
@@ -27,52 +27,50 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
 /**
  * A record reader that will generate a range of numbers.
+ * Refactored from Hadoop's teragen example.
  */
-public class RangeRecordReader 
+public class RangeRecordReader
     extends RecordReader<LongWritable, NullWritable> {
-    long startRow;
-    long finishedRows;
-    long totalRows;
-    LongWritable key = null;
 
-    public RangeRecordReader() {
-    }
-      
-    public void initialize(InputSplit split, TaskAttemptContext context) 
-        throws IOException, InterruptedException {
-        startRow = ((RangeInputSplit)split).firstRow;
-        finishedRows = 0;
-        totalRows = ((RangeInputSplit)split).rowCount;
-    }
+  long startRow;
+  long finishedRows;
+  long totalRows;
+  LongWritable key = null;
 
-    public void close() throws IOException {
-        // NOTHING
-    }
+  public RangeRecordReader() {}
 
-    public LongWritable getCurrentKey() {
-        return key;
-    }
+  public void initialize(InputSplit split, TaskAttemptContext context)
+      throws IOException, InterruptedException {
+    startRow = ((RangeInputSplit)split).firstRow;
+    finishedRows = 0;
+    totalRows = ((RangeInputSplit)split).rowCount;
+  }
 
-    public NullWritable getCurrentValue() {
-        return NullWritable.get();
-    }
+  public void close() throws IOException {}
 
-    public float getProgress() throws IOException {
-        return finishedRows / (float) totalRows;
-    }
+  public LongWritable getCurrentKey() {
+    return key;
+  }
 
-    public boolean nextKeyValue() {
-        if (key == null) {
-            key = new LongWritable();
-        }
-        if (finishedRows < totalRows) {
-            key.set(startRow + finishedRows);
-            finishedRows += 1;
-            return true;
-        } else {
-            return false;
-        }
+  public NullWritable getCurrentValue() {
+    return NullWritable.get();
+  }
+
+  public float getProgress() throws IOException {
+    return finishedRows / (float) totalRows;
+  }
+
+  public boolean nextKeyValue() {
+    if (key == null) {
+      key = new LongWritable();
     }
-      
+    if (finishedRows < totalRows) {
+      key.set(startRow + finishedRows);
+      finishedRows += 1;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
 }
-

--- a/examples/pseudo_terasort/pteragen.py
+++ b/examples/pseudo_terasort/pteragen.py
@@ -119,4 +119,4 @@ factory = pp.Factory(mapper_class=Mapper, record_writer_class=Writer)
 
 
 def __main__():
-    pp.run_task(factory)
+    pp.run_task(factory, auto_serialize=False)

--- a/examples/pseudo_terasort/pterasort.py
+++ b/examples/pseudo_terasort/pterasort.py
@@ -138,4 +138,4 @@ factory = pp.Factory(
 
 
 def __main__():
-    pp.run_task(factory, private_encoding=False)
+    pp.run_task(factory, private_encoding=False, auto_serialize=False)

--- a/examples/pseudo_terasort/run
+++ b/examples/pseudo_terasort/run
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+[ -n "${DEBUG:-}" ] && set -x
+this="${BASH_SOURCE-$0}"
+this_dir=$(cd -P -- "$(dirname -- "${this}")" && pwd -P)
+. "${this_dir}/../config.sh"
+
+(( ${PY_VER} == 3 )) || die "runs only on python 3"
+
+make genrecords
+make sortrecords
+make checkrecords

--- a/examples/run_all
+++ b/examples/run_all
@@ -23,6 +23,7 @@ trap exit ERR
 examples=(
     hdfs
     input_format
+    pseudo_terasort
     pydoop_script
     pydoop_submit
     self_contained
@@ -33,6 +34,7 @@ examples=(
 some_failed=0
 
 for e in ${examples[@]}; do
+    [ ${e} == pseudo_terasort ] && (( ${PY_VER} != 3 )) && continue
     pushd ${e}
     echo -ne "\n\n *** RUNNING ${e} EXAMPLE(S) ***\n\n"
     ./run

--- a/examples/run_all
+++ b/examples/run_all
@@ -18,6 +18,10 @@
 #
 # END_COPYRIGHT
 
+this="${BASH_SOURCE-$0}"
+this_dir=$(cd -P -- "$(dirname -- "${this}")" && pwd -P)
+. "${this_dir}/config.sh"
+
 trap exit ERR
 
 examples=(


### PR DESCRIPTION
* disable auto-serialization to bytes where appropriate
* allow external override of more Makefile params
* java source cleanup
* add example runner so that it's checked by travis (python3 only)

I've specifically marked the example as Python3-only. Since we use it for performance testing, it's best to avoid slowing it down with compatibility hacks. On the other hand, it does not add anything new w.r.t API/infrastructure usage that should be checked in both Python versions.