### PR TITLE
HDFS file: add buffered I/O wrapper

### DIFF
--- a/examples/hdfs/repl_session.py
+++ b/examples/hdfs/repl_session.py
@@ -2,7 +2,6 @@
 # DOCS_INCLUDE_START
 >>> import pydoop.hdfs as hdfs
 >>> hdfs.mkdir('test')
-True
 >>> hdfs.dump('hello, world', 'test/hello.txt')
 >>> hdfs.load('test/hello.txt')
 b'hello, world'

--- a/pydoop/hdfs/__init__.py
+++ b/pydoop/hdfs/__init__.py
@@ -151,8 +151,8 @@ def load(hdfs_path, **kwargs):
     Keyword arguments are passed to :func:`open`. The `"mode"` kwarg
     must be readonly.
     """
-    m = common.Mode(kwargs.get("mode", "r"))
-    if m.writable:
+    m, _ = common.parse_mode(kwargs.get("mode", "r"))
+    if m != "r":
         raise ValueError("opening mode must be readonly")
     data = []
     with open(hdfs_path, **kwargs) as fi:
@@ -169,9 +169,9 @@ def load(hdfs_path, **kwargs):
 
 def _cp_file(src_fs, src_path, dest_fs, dest_path, **kwargs):
     kwargs.pop("mode", None)
-    kwargs["flags"] = "r"
+    kwargs["mode"] = "r"
     with src_fs.open_file(src_path, **kwargs) as fi:
-        kwargs["flags"] = "w"
+        kwargs["mode"] = "w"
         with dest_fs.open_file(dest_path, **kwargs) as fo:
             bufsize = common.BUFSIZE
             while 1:

--- a/pydoop/hdfs/__init__.py
+++ b/pydoop/hdfs/__init__.py
@@ -113,8 +113,7 @@ from .fs import hdfs, default_is_local
 
 
 def open(hdfs_path, mode="r", buff_size=0, replication=0, blocksize=0,
-         readline_chunk_size=common.BUFSIZE, user=None,
-         encoding=None, errors=None):
+         user=None, encoding=None, errors=None):
     """
     Open a file, returning an :class:`~.file.hdfs_file` object.
 
@@ -125,7 +124,7 @@ def open(hdfs_path, mode="r", buff_size=0, replication=0, blocksize=0,
     host, port, path_ = path.split(hdfs_path, user)
     fs = hdfs(host, port, user)
     return fs.open_file(path_, mode, buff_size, replication, blocksize,
-                        readline_chunk_size, encoding, errors)
+                        encoding, errors)
 
 
 def dump(data, hdfs_path, **kwargs):

--- a/pydoop/hdfs/common.py
+++ b/pydoop/hdfs/common.py
@@ -24,7 +24,6 @@ import getpass
 import pwd
 import grp
 import sys
-import os
 
 __is_py3 = sys.version_info >= (3, 0)
 
@@ -41,104 +40,21 @@ TEXT_ENCODING = 'utf-8'
 # used by the native extension.
 
 
-class Mode(object):
-    """\
-    File opening mode.
+BASE_MODES = frozenset("rwa")
 
-    Supported mode strings are limited to ``'rb', 'wb', 'ab'`` (or simply
-    ``'r', 'w', 'a'``) for binary mode and ``'rt', 'wt', 'at'`` for text
-    mode. Semantics are similar to :func:`io.open`, but note that the default
-    mode is binary.
 
-    For backwards compatibility, the constructor also accepts
-    :data:`os.O_RDONLY`, :data:`os.O_WRONLY` and :data:`os.O_WRONLY` |
-    :data:`os.O_APPEND`, respectively equivalent to ``'rb', 'wb'`` and
-    ``'ab'``.
-    """
-
-    VALUE = {
-        "r": os.O_RDONLY,
-        "w": os.O_WRONLY,
-        "a": os.O_WRONLY | os.O_APPEND,
-    }
-
-    FLAGS = {
-        os.O_RDONLY: "r",
-        os.O_WRONLY: "w",
-        os.O_WRONLY | os.O_APPEND: "a",
-    }
-
-    @property
-    def value(self):
-        return self.__value
-
-    @property
-    def flags(self):
-        return self.__flags
-
-    @property
-    def text(self):
-        return self.__text
-
-    @property
-    def binary(self):
-        return not self.__text
-
-    @property
-    def writable(self):
-        return self.flags & os.O_WRONLY
-
-    def __init__(self, m=None):
-        if isinstance(m, self.__class__):
-            self.__value = m.value
-            self.__flags = m.flags
-            self.__text = m.text
-            return
-        else:
-            self.__value = "rb"
-            self.__flags = os.O_RDONLY
-            self.__text = False
-        if not m:
-            return
-        try:
-            self.__value = m[0]
-        except TypeError:
-            try:
-                self.__value = Mode.FLAGS[m]
-            except KeyError:
-                self.__error(m)
-            else:
-                self.__flags = m
-        else:
-            try:
-                self.__flags = Mode.VALUE[self.__value]
-            except KeyError:
-                self.__error(m)
-            else:
-                try:
-                    self.__text = m[1] == "t"
-                except IndexError:
-                    pass
-        self.__value += 't' if self.__text else 'b'
-
-    def __error(self, m):
-        raise ValueError("invalid mode: %r" % (m,))
-
-    def __eq__(self, m):
-        try:
-            return self.__class__(m).value == self.value
-        except ValueError:
-            return False
-
-    def __ne__(self, m):
-        return not self.__eq__(m)
-
-    def __str__(self):
-        return self.__value
-
-    @classmethod
-    def copy(cls, m):
-        return cls(m)
+def parse_mode(mode):
+    try:
+        base_mode = mode[0]
+    except IndexError:
+        raise ValueError("mode cannot be empty")
+    if base_mode not in BASE_MODES:
+        raise ValueError("base mode must be one of %s" % ", ".join(BASE_MODES))
+    try:
+        is_text = mode[1] == "t"
+    except IndexError:
+        is_text = False
+    return base_mode, is_text
 
 
 if __is_py3:

--- a/pydoop/hdfs/file.py
+++ b/pydoop/hdfs/file.py
@@ -55,7 +55,7 @@ class RawFileWrapper(object):
 
     @property
     def closed(self):
-        return self.f.is_closed()
+        return self.f.closed
 
     def readable(self):
         return self.f.readable()

--- a/pydoop/hdfs/fs.py
+++ b/pydoop/hdfs/fs.py
@@ -264,7 +264,7 @@ class hdfs(object):
             return fret
         f = self.fs.open_file(path, m.flags, buff_size, replication, blocksize)
         cls = FileIO if m.text else hdfs_file
-        fret = cls(f, self, path, m)
+        fret = cls(f, self, m)
         if m.flags == os.O_RDONLY:
             fret.seek(0)
         return fret

--- a/pydoop/hdfs/fs.py
+++ b/pydoop/hdfs/fs.py
@@ -226,7 +226,7 @@ class hdfs(object):
         return self.__status.refcount == 0
 
     def open_file(self, path,
-                  flags=os.O_RDONLY,
+                  mode="r",
                   buff_size=0,
                   replication=0,
                   blocksize=0,
@@ -235,14 +235,18 @@ class hdfs(object):
         """
         Open an HDFS file.
 
+        Supported opening modes are "r", "w", "a". In addition, a
+        trailing "t" can be added to specify text mode (e.g., "rt" =
+        open for reading text).
+
         Pass 0 as ``buff_size``, ``replication`` or ``blocksize`` if you want
         to use the "configured" values, i.e., the ones set in the Hadoop
         configuration files.
 
         :type path: str
         :param path: the full path to the file
-        :type flags: str or int
-        :param flags: opening mode (see :class:`~.common.Mode`).
+        :type mode: str
+        :param mode: opening mode
         :type buff_size: int
         :param buff_size: read/write buffer size in bytes
         :type replication: int
@@ -251,22 +255,21 @@ class hdfs(object):
         :param blocksize: HDFS block size
         :rtpye: :class:`~.file.hdfs_file`
         :return: handle to the open file
+
         """
         _complain_ifclosed(self.closed)
         if not path:
             raise ValueError("Empty path")
-        m = common.Mode(flags)
+        m, is_text = common.parse_mode(mode)
         if not self.host:
-            fret = local_file(self, path, common.Mode(m.value[0]))
-            if m.text:
-                cls = io.BufferedWriter if m.writable else io.BufferedReader
+            fret = local_file(self, path, m)
+            if is_text:
+                cls = io.BufferedReader if m == "r" else io.BufferedWriter
                 fret = TextIOWrapper(cls(fret), encoding, errors)
             return fret
-        f = self.fs.open_file(path, m.flags, buff_size, replication, blocksize)
-        cls = FileIO if m.text else hdfs_file
-        fret = cls(f, self, m)
-        if m.flags == os.O_RDONLY:
-            fret.seek(0)
+        f = self.fs.open_file(path, m, buff_size, replication, blocksize)
+        cls = FileIO if is_text else hdfs_file
+        fret = cls(f, self, mode)
         return fret
 
     def capacity(self):

--- a/pydoop/hdfs/fs.py
+++ b/pydoop/hdfs/fs.py
@@ -230,7 +230,6 @@ class hdfs(object):
                   buff_size=0,
                   replication=0,
                   blocksize=0,
-                  readline_chunk_size=common.BUFSIZE,
                   encoding=None,
                   errors=None):
         """
@@ -250,9 +249,6 @@ class hdfs(object):
         :param replication: HDFS block replication
         :type blocksize: int
         :param blocksize: HDFS block size
-        :type readline_chunk_size: int
-        :param readline_chunk_size: the amount of bytes that
-          :meth:`~.file.hdfs_file.readline` will use for buffering
         :rtpye: :class:`~.file.hdfs_file`
         :return: handle to the open file
         """
@@ -268,7 +264,7 @@ class hdfs(object):
             return fret
         f = self.fs.open_file(path, m.flags, buff_size, replication, blocksize)
         cls = FileIO if m.text else hdfs_file
-        fret = cls(f, self, path, m, readline_chunk_size)
+        fret = cls(f, self, path, m)
         if m.flags == os.O_RDONLY:
             fret.seek(0)
         return fret

--- a/src/native_core_hdfs/hdfs_file.cc
+++ b/src/native_core_hdfs/hdfs_file.cc
@@ -34,7 +34,6 @@ PyObject* FileClass_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         self->buff_size = 0;
         self->replication = 1;
         self->blocksize = 0;
-        self->readline_chunk_size = 16 * 1024; // 16 KB
         self->closed = 0;
     }
     return (PyObject *)self;
@@ -80,6 +79,11 @@ PyObject* FileClass_close(FileInfo* self){
 
 PyObject* FileClass_getclosed(FileInfo* self, void* closure) {
   return PyBool_FromLong(self->closed);
+}
+
+
+PyObject* FileClass_getbuff_size(FileInfo* self, void* closure) {
+  return PyLong_FromLong(self->buff_size);
 }
 
 

--- a/src/native_core_hdfs/hdfs_file.cc
+++ b/src/native_core_hdfs/hdfs_file.cc
@@ -34,7 +34,10 @@ PyObject* FileClass_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             Py_DECREF(self);
             return NULL;
         }
-        self->flags = 0;
+        if (NULL == (self->mode = PyUnicode_FromString(""))) {
+            Py_DECREF(self);
+            return NULL;
+        }
         self->buff_size = 0;
         self->replication = 1;
         self->blocksize = 0;
@@ -53,9 +56,10 @@ void FileClass_dealloc(FileInfo* self)
 
 int FileClass_init(FileInfo *self, PyObject *args, PyObject *kwds)
 {
-    PyObject *name = NULL, *tmp;
+    PyObject *name = NULL, *mode = NULL, *tmp;
 
-    if (! PyArg_ParseTuple(args, "OOO", &(self->fs), &(self->file), &name)) {
+    if (!PyArg_ParseTuple(args, "OOOO",
+                          &(self->fs), &(self->file), &name, &mode)) {
         return -1;
     }
 
@@ -63,6 +67,12 @@ int FileClass_init(FileInfo *self, PyObject *args, PyObject *kwds)
 	tmp = self->name;
 	Py_INCREF(name);
 	self->name = name;
+	Py_XDECREF(tmp);
+    }
+    if (mode) {
+	tmp = self->mode;
+	Py_INCREF(mode);
+	self->mode = mode;
 	Py_XDECREF(tmp);
     }
 
@@ -103,6 +113,12 @@ PyObject* FileClass_getbuff_size(FileInfo* self, void* closure) {
 PyObject* FileClass_getname(FileInfo* self, void* closure) {
     Py_INCREF(self->name);
     return self->name;
+}
+
+
+PyObject* FileClass_getmode(FileInfo* self, void* closure) {
+    Py_INCREF(self->mode);
+    return self->mode;
 }
 
 

--- a/src/native_core_hdfs/hdfs_file.cc
+++ b/src/native_core_hdfs/hdfs_file.cc
@@ -30,6 +30,10 @@ PyObject* FileClass_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (self != NULL) {
         self->fs = NULL;
         self->file = NULL;
+        if (NULL == (self->name = PyUnicode_FromString(""))) {
+            Py_DECREF(self);
+            return NULL;
+        }
         self->flags = 0;
         self->buff_size = 0;
         self->replication = 1;
@@ -49,8 +53,17 @@ void FileClass_dealloc(FileInfo* self)
 
 int FileClass_init(FileInfo *self, PyObject *args, PyObject *kwds)
 {
-    if (! PyArg_ParseTuple(args, "OO", &(self->fs), &(self->file))) {
+    PyObject *name = NULL, *tmp;
+
+    if (! PyArg_ParseTuple(args, "OOO", &(self->fs), &(self->file), &name)) {
         return -1;
+    }
+
+    if (name) {
+	tmp = self->name;
+	Py_INCREF(name);
+	self->name = name;
+	Py_XDECREF(tmp);
     }
 
     return 0;
@@ -84,6 +97,12 @@ PyObject* FileClass_getclosed(FileInfo* self, void* closure) {
 
 PyObject* FileClass_getbuff_size(FileInfo* self, void* closure) {
   return PyLong_FromLong(self->buff_size);
+}
+
+
+PyObject* FileClass_getname(FileInfo* self, void* closure) {
+    Py_INCREF(self->name);
+    return self->name;
 }
 
 

--- a/src/native_core_hdfs/hdfs_file.cc
+++ b/src/native_core_hdfs/hdfs_file.cc
@@ -78,7 +78,7 @@ PyObject* FileClass_close(FileInfo* self){
 }
 
 
-PyObject* FileClass_is_closed(FileInfo* self) {
+PyObject* FileClass_getclosed(FileInfo* self, void* closure) {
   return PyBool_FromLong(self->closed);
 }
 

--- a/src/native_core_hdfs/hdfs_file.h
+++ b/src/native_core_hdfs/hdfs_file.h
@@ -22,7 +22,6 @@
 
 #include <Python.h>
 
-
 #include <string>
 #include <map>
 #include <utility>  // std::pair support
@@ -36,19 +35,17 @@
 #include "../py3k_compat.h"
 
 
-
 typedef struct {
     PyObject_HEAD
     hdfsFS fs;
     hdfsFile file;
     PyObject *name;
-    int flags;
+    PyObject *mode;
     int buff_size;
     short replication;
     int blocksize;
     int closed;
 } FileInfo;
-
 
 
 PyObject* FileClass_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
@@ -66,6 +63,8 @@ PyObject* FileClass_getclosed(FileInfo* self, void* closure);
 PyObject* FileClass_getbuff_size(FileInfo* self, void* closure);
 
 PyObject* FileClass_getname(FileInfo* self, void* closure);
+
+PyObject* FileClass_getmode(FileInfo* self, void* closure);
 
 PyObject* FileClass_readable(FileInfo* self);
 

--- a/src/native_core_hdfs/hdfs_file.h
+++ b/src/native_core_hdfs/hdfs_file.h
@@ -47,7 +47,6 @@ typedef struct {
     int buff_size;
     short replication;
     int blocksize;
-    int readline_chunk_size;
     int closed;
 } FileInfo;
 
@@ -64,6 +63,8 @@ int FileClass_init_internal(FileInfo *self, hdfsFS fs, hdfsFile file);
 PyObject* FileClass_close(FileInfo* self);
 
 PyObject* FileClass_getclosed(FileInfo* self, void* closure);
+
+PyObject* FileClass_getbuff_size(FileInfo* self, void* closure);
 
 PyObject* FileClass_readable(FileInfo* self);
 

--- a/src/native_core_hdfs/hdfs_file.h
+++ b/src/native_core_hdfs/hdfs_file.h
@@ -63,7 +63,7 @@ int FileClass_init_internal(FileInfo *self, hdfsFS fs, hdfsFile file);
 
 PyObject* FileClass_close(FileInfo* self);
 
-PyObject* FileClass_is_closed(FileInfo* self);
+PyObject* FileClass_getclosed(FileInfo* self, void* closure);
 
 PyObject* FileClass_readable(FileInfo* self);
 

--- a/src/native_core_hdfs/hdfs_file.h
+++ b/src/native_core_hdfs/hdfs_file.h
@@ -41,8 +41,7 @@ typedef struct {
     PyObject_HEAD
     hdfsFS fs;
     hdfsFile file;
-    // LP: do we need this? const char* path;
-    // If so, we should try to convert it to a PyObject* and use reference counting
+    PyObject *name;
     int flags;
     int buff_size;
     short replication;
@@ -65,6 +64,8 @@ PyObject* FileClass_close(FileInfo* self);
 PyObject* FileClass_getclosed(FileInfo* self, void* closure);
 
 PyObject* FileClass_getbuff_size(FileInfo* self, void* closure);
+
+PyObject* FileClass_getname(FileInfo* self, void* closure);
 
 PyObject* FileClass_readable(FileInfo* self);
 

--- a/src/native_core_hdfs/hdfs_file.h
+++ b/src/native_core_hdfs/hdfs_file.h
@@ -48,6 +48,7 @@ typedef struct {
     short replication;
     int blocksize;
     int readline_chunk_size;
+    int closed;
 } FileInfo;
 
 
@@ -61,6 +62,14 @@ int FileClass_init(FileInfo *self, PyObject *args, PyObject *kwds);
 int FileClass_init_internal(FileInfo *self, hdfsFS fs, hdfsFile file);
 
 PyObject* FileClass_close(FileInfo* self);
+
+PyObject* FileClass_is_closed(FileInfo* self);
+
+PyObject* FileClass_readable(FileInfo* self);
+
+PyObject* FileClass_writable(FileInfo* self);
+
+PyObject* FileClass_seekable(FileInfo* self);
 
 PyObject* FileClass_mode(FileInfo* self);
 

--- a/src/native_core_hdfs/hdfs_file.h
+++ b/src/native_core_hdfs/hdfs_file.h
@@ -41,6 +41,7 @@ typedef struct {
     hdfsFile file;
     PyObject *name;
     PyObject *mode;
+    tOffset size;
     int buff_size;
     short replication;
     int blocksize;

--- a/src/native_core_hdfs/hdfs_fs.cc
+++ b/src/native_core_hdfs/hdfs_fs.cc
@@ -310,14 +310,16 @@ PyObject* FsClass_open_file(FsInfo* self, PyObject *args, PyObject *kwds)
 	free(file);
 	return NULL;
     }
-    retval = PyObject_CallMethod(module, "CoreHdfsFile", "OO", self->_fs, file);
+    PyObject *name = PyUnicode_FromString(path);
+    retval = PyObject_CallMethod(module, "CoreHdfsFile", "OOO",
+				 self->_fs, file, name);
+    Py_XDECREF(name);
+    Py_XDECREF(module);
     if (NULL == retval) {
-	Py_XDECREF(module);
 	free(file);
 	return NULL;
     }
     FileInfo *fileInfo = ((FileInfo*) retval);
-    // LP: see hdfs_file.h: fileInfo->path = path;
     fileInfo->flags = flags;
     fileInfo->buff_size = buff_size;
     fileInfo->blocksize = blocksize;

--- a/src/native_core_hdfs/hdfs_fs.cc
+++ b/src/native_core_hdfs/hdfs_fs.cc
@@ -293,13 +293,13 @@ PyObject* FsClass_open_file(FsInfo* self, PyObject *args, PyObject *kwds)
 {
     PyObject* retval = NULL;
     const char* path = NULL;
-    int flags, buff_size, blocksize, readline_chunk_size;
+    int flags, buff_size, blocksize;
     short replication;
     hdfsFile file;
 
-    if (!PyArg_ParseTuple(args, "es|iihii",
+    if (!PyArg_ParseTuple(args, "es|iihi",
                           "utf-8", &path, &flags, &buff_size, &replication,
-                          &blocksize, &readline_chunk_size)) {
+                          &blocksize)) {
         return NULL;
     }
 
@@ -328,7 +328,6 @@ PyObject* FsClass_open_file(FsInfo* self, PyObject *args, PyObject *kwds)
         fileInfo->buff_size = buff_size;
         fileInfo->blocksize = blocksize;
         fileInfo->replication = replication;
-        fileInfo->readline_chunk_size = readline_chunk_size;
     }
 done:
     PyMem_Free((void*)path);

--- a/src/native_core_hdfs/hdfs_fs.h
+++ b/src/native_core_hdfs/hdfs_fs.h
@@ -34,6 +34,11 @@
 #include "../py3k_compat.h"
 
 
+#define MODE_READ "r"
+#define MODE_WRITE "w"
+#define MODE_APPEND "a"
+
+
 typedef struct {
     PyObject_HEAD
     char *host;

--- a/src/native_core_hdfs/hdfs_module.cc
+++ b/src/native_core_hdfs/hdfs_module.cc
@@ -146,6 +146,9 @@ static PyMethodDef FileClass_methods[] = {
   {"read", (PyCFunction) FileClass_read, METH_VARARGS, "Read from the file"},
   {"read_chunk", (PyCFunction) FileClass_read_chunk, METH_VARARGS,
    "Like read, but store data to the given buffer"},
+  /* Also export read_chunk as readinto for compatibility with Python io */
+  {"readinto", (PyCFunction) FileClass_read_chunk, METH_VARARGS,
+   "Like read, but store data to the given buffer"},
   {"pread", (PyCFunction) FileClass_pread, METH_VARARGS,
    "Read starting from the given position"},
   {"pread_chunk", (PyCFunction) FileClass_pread_chunk, METH_VARARGS,

--- a/src/native_core_hdfs/hdfs_module.cc
+++ b/src/native_core_hdfs/hdfs_module.cc
@@ -124,6 +124,14 @@ static PyMemberDef FileClass_members[] = {
 
 static PyMethodDef FileClass_methods[] = {
   {"close", (PyCFunction)FileClass_close, METH_NOARGS, "Close the file"},
+  {"is_closed", (PyCFunction)FileClass_is_closed, METH_NOARGS,
+   "True if the file is closed"},
+  {"readable", (PyCFunction)FileClass_readable, METH_NOARGS,
+   "True if the file can be read from"},
+  {"writable", (PyCFunction)FileClass_writable, METH_NOARGS,
+   "True if the file can be written to"},
+  {"seekable", (PyCFunction)FileClass_seekable, METH_NOARGS,
+   "True if the file support random access (it does if it's readable)"},
   {"available", (PyCFunction) FileClass_available, METH_NOARGS,
    "Number of bytes that can be read without blocking"},
   {"write", (PyCFunction)FileClass_write, METH_VARARGS, "Write to the file"},

--- a/src/native_core_hdfs/hdfs_module.cc
+++ b/src/native_core_hdfs/hdfs_module.cc
@@ -122,10 +122,13 @@ static PyMemberDef FileClass_members[] = {
   {NULL}  /* Sentinel */
 };
 
+static PyGetSetDef FileClass_getseters[] = {
+  {"closed", (getter)FileClass_getclosed, NULL, NULL},
+  {NULL}  /* Sentinel */
+};
+
 static PyMethodDef FileClass_methods[] = {
   {"close", (PyCFunction)FileClass_close, METH_NOARGS, "Close the file"},
-  {"is_closed", (PyCFunction)FileClass_is_closed, METH_NOARGS,
-   "True if the file is closed"},
   {"readable", (PyCFunction)FileClass_readable, METH_NOARGS,
    "True if the file can be read from"},
   {"writable", (PyCFunction)FileClass_writable, METH_NOARGS,
@@ -181,7 +184,7 @@ static PyTypeObject FileType = {
   0,                                        /* tp_iternext */
   FileClass_methods,                        /* tp_methods */
   FileClass_members,                        /* tp_members */
-  0,                                        /* tp_getset */
+  FileClass_getseters,                      /* tp_getset */
   0,                                        /* tp_base */
   0,                                        /* tp_dict */
   0,                                        /* tp_descr_get */

--- a/src/native_core_hdfs/hdfs_module.cc
+++ b/src/native_core_hdfs/hdfs_module.cc
@@ -125,6 +125,7 @@ static PyMemberDef FileClass_members[] = {
 static PyGetSetDef FileClass_getseters[] = {
   {"closed", (getter)FileClass_getclosed, NULL, NULL},
   {"buff_size", (getter)FileClass_getbuff_size, NULL, NULL},
+  {"name", (getter)FileClass_getname, NULL, NULL},
   {NULL}  /* Sentinel */
 };
 

--- a/src/native_core_hdfs/hdfs_module.cc
+++ b/src/native_core_hdfs/hdfs_module.cc
@@ -124,6 +124,7 @@ static PyMemberDef FileClass_members[] = {
 
 static PyGetSetDef FileClass_getseters[] = {
   {"closed", (getter)FileClass_getclosed, NULL, NULL},
+  {"buff_size", (getter)FileClass_getbuff_size, NULL, NULL},
   {NULL}  /* Sentinel */
 };
 

--- a/src/native_core_hdfs/hdfs_module.cc
+++ b/src/native_core_hdfs/hdfs_module.cc
@@ -126,6 +126,7 @@ static PyGetSetDef FileClass_getseters[] = {
   {"closed", (getter)FileClass_getclosed, NULL, NULL},
   {"buff_size", (getter)FileClass_getbuff_size, NULL, NULL},
   {"name", (getter)FileClass_getname, NULL, NULL},
+  {"mode", (getter)FileClass_getmode, NULL, NULL},
   {NULL}  /* Sentinel */
 };
 
@@ -266,6 +267,10 @@ initnative_core_hdfs(void)
   Py_INCREF(&FileType);
   PyModule_AddObject(m, "CoreHdfsFs", (PyObject *)&FsType);
   PyModule_AddObject(m, "CoreHdfsFile", (PyObject *)&FileType);
+
+  PyModule_AddStringConstant(m, "MODE_READ", MODE_READ);
+  PyModule_AddStringConstant(m, "MODE_WRITE", MODE_WRITE);
+  PyModule_AddStringConstant(m, "MODE_APPEND", MODE_APPEND);
 }
 #endif
 

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -301,7 +301,7 @@ class TestCommon(unittest.TestCase):
             )
             self.assertEqual(f.tell(), 0)
             self.assertEqual(content[1:], f.pread(1, -1))
-            self.assertRaises(ValueError, f.pread, -1, 10)
+            self.assertRaises(IOError, f.pread, -1, 10)
             # read starting past end of file
             self.assertRaises(IOError, f.pread, len(content) + 1, 10)
             # read past end of file

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -58,7 +58,7 @@ class TestCommon(unittest.TestCase):
 
     # also an implicit test for the write method
     def _make_random_file(self, where=None, content=None, **kwargs):
-        kwargs["flags"] = "w"
+        kwargs["mode"] = "w"
         content = content or utils.make_random_data(printable=True)
         path = self._make_random_path(where=where)
         with self.fs.open_file(path, **kwargs) as fo:
@@ -80,14 +80,12 @@ class TestCommon(unittest.TestCase):
     assertRaisesExternal = failUnlessRaisesExternal
 
     def open_close(self):
-        for flags in "w", os.O_WRONLY:
-            path = self._make_random_path()
-            self.fs.open_file(path, flags).close()
-            for flags in "r", os.O_RDONLY:
-                with self.fs.open_file(path, flags) as f:
-                    self.assertFalse(f.closed)
-                self.assertTrue(f.closed)
-                self.assertRaises(ValueError, f.read)
+        path = self._make_random_path()
+        self.fs.open_file(path, "w").close()
+        with self.fs.open_file(path, "r") as f:
+            self.assertFalse(f.closed)
+        self.assertTrue(f.closed)
+        self.assertRaises(ValueError, f.read)
         path = self._make_random_path()
         self.assertRaisesExternal(IOError, self.fs.open_file, path, "r")
         self.assertRaises(ValueError, self.fs.open_file, "")
@@ -181,6 +179,7 @@ class TestCommon(unittest.TestCase):
                 self.assertTrue(f.fs is self.fs)
                 self.assertEqual(f.size, 0)
                 self.assertEqual(f.mode, mode)
+                self.assertTrue(f.writable())
                 f.write(content if mode == "wb" else content.decode("utf-8"))
             self.assertEqual(f.size, len(content))
         for mode in "rb", "rt":
@@ -189,6 +188,7 @@ class TestCommon(unittest.TestCase):
                 self.assertTrue(f.fs is self.fs)
                 self.assertEqual(f.size, len(content))
                 self.assertEqual(f.mode, mode)
+                self.assertFalse(f.writable())
 
     def flush(self):
         path = self._make_random_path()

--- a/test/hdfs/common_hdfs_tests.py
+++ b/test/hdfs/common_hdfs_tests.py
@@ -268,14 +268,6 @@ class TestCommon(unittest.TestCase):
             bytes_written = fo.write(chunk)
             self.assertEqual(bytes_written, len(content))
 
-    def write_chunk(self):
-        content = utils.make_random_data()
-        chunk = create_string_buffer(content, len(content))
-        path = self._make_random_path()
-        with self.fs.open_file(path, "w") as fo:
-            bytes_written = fo.write_chunk(chunk)
-            self.assertEqual(bytes_written, len(content))
-
     def append(self):
         replication = 1  # see https://issues.apache.org/jira/browse/HDFS-3091
         content, update = utils.make_random_data(), utils.make_random_data()
@@ -409,6 +401,16 @@ class TestCommon(unittest.TestCase):
                 line, x, "len(a) = %d, len(x) = %d" % (len(line), len(x))
             )
 
+    def readline_and_read(self):
+        content = b"first line\nsecond line\n"
+        path = self._make_random_file(content=content)
+        chunks = []
+        with self.fs.open_file(path) as f:
+            chunks.append(f.read(1))
+            chunks.append(f.readline())
+            chunks.append(f.read(4))
+        self.assertEqual(chunks, [b'f', b'irst line\n', b'seco'])
+
     def iter_lines(self):
 
         def get_lines_explicit(f):
@@ -529,8 +531,6 @@ class TestCommon(unittest.TestCase):
         data = text.encode("utf-8")
         with self.fs.open_file(t_path, "wt") as fo:
             chars_written = fo.write(text)
-            with self.assertRaises(AttributeError):
-                fo.write_chunk(u"foo")
         with self.fs.open_file(b_path, "w") as fo:
             bytes_written = fo.write(data)
         self.assertEqual(chars_written, len(text))
@@ -569,7 +569,6 @@ def common_tests():
         'read',
         'read_chunk',
         'write',
-        'write_chunk',
         'append',
         'tell',
         'pread',
@@ -582,6 +581,7 @@ def common_tests():
         'list_directory',
         'readline',
         'readline_big',
+        'readline_and_read',
         'iter_lines',
         'seek',
         'block_boundary',

--- a/test/hdfs/test_hdfs_fs.py
+++ b/test/hdfs/test_hdfs_fs.py
@@ -162,7 +162,7 @@ class TestHDFS(TestCommon):
         line = b"012345678\n"
         offset = bs - (10 * len(line) + 5)
         path = self._make_random_path()
-        with self.fs.open_file(path, flags="w", **kwargs) as f:
+        with self.fs.open_file(path, mode="w", **kwargs) as f:
             bytes_written = lines_written = 0
             _write_prefix(f, offset, bs)
             bytes_written = offset


### PR DESCRIPTION
Fixes #280.

**UPDATE (2018-03-06): pushed features needed by buffered I/O to the C level and removed RawFileWrapper, see comments**

This PR rearranges the HDFS file object code so that we can take advantage of the functionalities provided by [buffered I/O](https://docs.python.org/3/library/io.html) in the standard library:

* The new `RawFileWrapper`, together with changes at the C/C++ level, provides a minimal subset of the interface expected by `io.Buffered{Reader,Writer}`, which appears to be sufficient for our current purposes. 

* Our `FileIO` object has been changed to wrap an `io.Buffered{Reader,Writer}` which, in turn, wraps `RawFileWrapper`. This effectively offloads some buffering-related operations to the standard library. In particular, `io.BufferedReader` provides a `readline` method (implemented in C), so our implementation is not needed anymore.

* A new test checks that #280 is now fixed.

* `write_chunk` has been removed. Probably a leftover from the old API, at this point it's the same thing as `write`.

**Performance notes:**

I've quickly compared `write` and `readline` timings with and without this PR, with the following simple code:

```python
import time
import random
import pydoop.hdfs as hdfs

lines = []
with open("/pydoop/examples/input/alice_1.txt", "rb") as f:
    for l in f:
        for i in range(10):
            lines.append(l)
random.shuffle(lines)

with hdfs.open("junk.txt", "wb") as f:
    start = time.time()
    for l in lines:
        f.write(l)
    wt = time.time() - start

lines_from_file = []
with hdfs.open("junk.txt", "rb") as f:
    start = time.time()
    for l in f:
        lines_from_file.append(l)
    rt = time.time() - start

assert lines_from_file == lines

print("%.3f\t%.3f" % (wt, rt))
```
Average timings (s) over 5 iterations (18280 lines, av. len = 46 bytes):

| PR? | READ | WRITE |
|-----|------|-------|
| no  | .072 | .147  |
| yes | .040 | .068  |
