### PR TITLE
Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ COPY . /build/pydoop
 WORKDIR /build/pydoop
 
 RUN source /etc/profile && for v in 2 3; do \
-      pip${v} install --upgrade pip && \
-      pip${v} install --upgrade -r requirements.txt && \
+      pip${v} install --no-cache-dir --upgrade -r requirements.txt && \
       python${v} setup.py build && \
-      python${v} setup.py install --skip-build; \
+      python${v} setup.py install --skip-build && \
+      python${v} setup.py clean; \
     done

--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -5,10 +5,10 @@ COPY . /build/pydoop
 WORKDIR /build/pydoop
 
 RUN source /etc/profile && \
-    pip3 install --upgrade pip && \
-    pip3 install --upgrade -r requirements.txt && \
+    pip3 install --no-cache-dir --upgrade -r requirements.txt && \
     python3 setup.py build && \
-    python3 setup.py install --skip-build
+    python3 setup.py install --skip-build && \
+    python3 setup.py clean
 
 RUN inkscape -z -D -f logo/logo.svg -e /tmp/logo.png -w 800 && \
     convert -resize 200x /tmp/logo.png docs/_static/logo.png

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -7,17 +7,21 @@ RUN curl https://bintray.com/sbt/rpm/rpm -o /etc/yum.repos.d/bintray-sbt-rpm.rep
 # needed only to run examples: zip, wheel, sbt
 # needed TEMPORARILY: bc (https://github.com/sbt/sbt-launcher-package/pull/191)
 RUN yum install \
-    bc \
-    gcc \
-    gcc-c++ \
-    python-devel \
-    python-pip \
-    python36u-devel \
-    python36u-pip \
-    sbt \
-    zip
-RUN ln -rs /usr/bin/python3.6 /usr/bin/python3 && \
-    ln -rs /usr/bin/pip3.6 /usr/bin/pip3
+      bc \
+      gcc \
+      gcc-c++ \
+      python-devel \
+      python-pip \
+      python36u-devel \
+      python36u-pip \
+      sbt \
+      zip && \
+    yum clean all && \
+    ln -rs /usr/bin/python3.6 /usr/bin/python3 && \
+    ln -rs /usr/bin/pip3.6 /usr/bin/pip3 && \
+    for v in 2 3; do \
+      pip${v} install --no-cache-dir --upgrade pip; \
+    done
 
 ENV HADOOP_HOME /opt/hadoop
 ENV LC_ALL en_US.UTF-8

--- a/docker/Dockerfile.docsbase
+++ b/docker/Dockerfile.docsbase
@@ -1,5 +1,7 @@
 FROM crs4/pydoop-base
 MAINTAINER simone.leo@crs4.it
 
-RUN yum install inkscape  # installs ImageMagick as a dep
-RUN pip3 install sphinx
+# Inkscape installs ImageMagick as a dep
+RUN yum install inkscape && \
+    yum clean all && \
+    pip3 install --no-cache-dir sphinx


### PR DESCRIPTION
* reduce number of layers
* run `yum clean`
* disable pip cache
* run `python setup.py clean`

```
BEFORE:
crs4/pydoop-docs      1.92GB
crs4/pydoop           1.53GB
crs4/pydoop-docs-base 1.9GB
crs4/pydoop-base      1.49GB

AFTER:
crs4/pydoop-docs       1.67GB
crs4/pydoop            1.4GB
crs4/pydoop-docs-base  1.65GB
crs4/pydoop-base       1.37GB
```