### PR TITLE
Fixes  #284: pydoop app crashes when given no arguments.

### DIFF
--- a/pydoop/app/main.py
+++ b/pydoop/app/main.py
@@ -79,6 +79,10 @@ def main(argv=None):
             args.combine_fn = args.combiner_fn  # backwards compatibility
     except AttributeError:  # not the script app
         pass
+
+    if not hasattr(args, 'func'):
+        parser.print_usage()
+        sys.exit(0)
     try:
         args.func(args, unknown)
     except RuntimeError as e:


### PR DESCRIPTION
Fixes #284.

before applying this patch:

`root@3a156fd26465 test]# pydoop
Traceback (most recent call last):
  File "/usr/bin/pydoop", line 11, in <module>
    load_entry_point('pydoop==2.0a1', 'console_scripts', 'pydoop')()
  File "/usr/lib/python3.6/site-packages/pydoop-2.0a1-py3.6.egg/pydoop/app/main.py", line 83, in main
    args.func(args, unknown)
AttributeError: 'Namespace' object has no attribute 'func'`

after:
`[root@4eb30b9b9af0 test]# pydoop
usage: pydoop [-h] [-V] {script,submit} ...`


`