### PR TITLE
Update docs template

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -76,7 +76,8 @@
 	<li><a href="{{ pathto('index') }}">Home</a>|&nbsp;</li>
 	<li><a href="{{ pathto('installation') }}">Download & Install</a>|&nbsp;</li>
 	<li><a href="https://github.com/crs4/pydoop/issues">Support</a>|&nbsp;</li>
-	<li><a href="https://github.com/crs4/pydoop">Git Repo</a></li>
+	<li><a href="https://github.com/crs4/pydoop">Git Repo</a>|&nbsp;</li>
+	<li><a href="https://crs4.github.io/pydoop/_pydoop1">Pydoop 1</a></li>
 {% endblock %}
 
 {# put the sidebar before the body #}

--- a/docs/news/latest.rst
+++ b/docs/news/latest.rst
@@ -1,5 +1,5 @@
-New in 2.0.0-alpha1
--------------------
+New in 2.0a1
+------------
 
  * Added support for Python 3
  * `Dropped support for Hadoop 1 <https://github.com/crs4/pydoop/pull/237>`_


### PR DESCRIPTION
In [gh-pages](https://github.com/crs4/pydoop/tree/gh-pages) I have manually created a `_pydoop1` subdir to keep the v1 docs for future reference (we might drop them when we feel no one needs them anymore). This PR updates the docs template by adding a reference to the v1 docs. Before moving them to the subdir, in turn, the v1 docs have been altered to also include a back reference to the main (latest) docs.

I have also included a hotfix for the version string (the docs still had "2.0.0-alpha1" from a previous iteration).

`gh-pages` has already been pushed, so the effects of this PR are live at https://crs4.github.io/pydoop.