### PR TITLE
Fixes for building on EMR 5.12

### DIFF
--- a/test/hdfs/test_path.py
+++ b/test/hdfs/test_path.py
@@ -16,7 +16,6 @@
 #
 # END_COPYRIGHT
 
-import sys
 import os
 import unittest
 import tempfile
@@ -442,9 +441,7 @@ class TestReal(unittest.TestCase):
         wd = 'file:%s' % wd_
         link = os.path.join(wd_, make_random_str())
         os.symlink(wd_, link)
-        expected_path = ('file:%s%s' % ("/private", wd_)
-                         if sys.platform == "darwin"
-                         else 'file:%s' % wd_)
+        expected_path = 'file:%s' % os.path.realpath(wd_)
         self.assertEqual(hdfs.path.realpath('file:%s' % link), expected_path)
         hdfs.rmr(wd)
 


### PR DESCRIPTION
Fixes #167 
Fixes #214

With this PR, Pydoop builds on EMR 5.12 and all tests pass.

```
sudo yum install git
export JAVA_HOME=/etc/alternatives/java_sdk
git clone https://github.com/simleo/pydoop
cd pydoop
git checkout emr_misc
python setup.py build
sudo -E python setup.py install --skip-build
cd test
export HDFS_PORT=8020
python all_tests.py
```
