### PR TITLE
Docker target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,8 @@ run_docker:
     -p 10020:10020 -p 19888:19888 -p 50010:50010 -p 50020:50020 \
     -p 50070:50070 -p 50075:50075 -p 50090:50090 \
     -v ${TMP_CONF}:/opt/hadoop/etc/hadoop \
+    -v ${PWD}/examples:/build/pydoop/examples \
+    -v ${PWD}/test:/build/pydoop/test \
     -d crs4/pydoop;
 	@echo ""
 	@echo "* WARNING: Hadoop is using ${TMP_CONF} as configuration directory. *"

--- a/dev_tools/edit_conf
+++ b/dev_tools/edit_conf
@@ -30,8 +30,8 @@ def dict_to_doc(props):
     root.addprevious(pi)
     for k in props:
         p = ET.SubElement(root, "property")
-        name = ET.SubElement(root, "name")
-        val = ET.SubElement(root, "value")
+        name = ET.SubElement(p, "name")
+        val = ET.SubElement(p, "value")
         name.text, val.text = k, props[k]
     return doc
 
@@ -39,12 +39,14 @@ def main(argv):
     assert len(argv) >= 2 and not (len(argv) & 0x01)
     conf_input = argv[0]
     conf_output = argv[1]
-    nprops = len(argv[2:]) // 2
     doc = ET.parse(conf_input)
     props = doc_to_dict(doc)
+    ai = iter(argv[2:])
+    for k, v in zip(ai, ai):
+        props[k] = v
     ndoc = dict_to_doc(props)
     with open(conf_output, 'wb') as f:
-        f.write(ET.tostring(doc,
+        f.write(ET.tostring(ndoc,
                 encoding="utf-8",                                
                 xml_declaration=True))
 

--- a/dev_tools/edit_conf
+++ b/dev_tools/edit_conf
@@ -11,38 +11,42 @@ Usage::
 
 """
 
-from lxml import etree
+from lxml import etree as ET
 import sys
 
-
-def add_replace(data, key, value):
-    root = etree.fromstring(data)
-    found = False
+def doc_to_dict(doc):
+    props = {}
+    root = doc.getroot()
     for p in root.findall('property'):
-        if p.find('name').text == key:
-            p.find('value').text = value
-            found = True
-    if not found:
-        p = etree.SubElement(root, "property")
-        name = etree.SubElement(p, "name")
-        val = etree.SubElement(p, "value")
-        name.text, val.text = key, value
-    return etree.tostring(root, pretty_print=True)
+        props[p.find('name').text] = p.find('value').text
+    return props
 
+def dict_to_doc(props):
+    doc = ET.ElementTree(ET.fromstring('<configuration/>'))
+    root = doc.getroot()
+    pi = ET.ProcessingInstruction(
+        'xml-stylesheet',
+        'type="text/xsl" href="configuration.xsl"')
+    root.addprevious(pi)
+    for k in props:
+        p = ET.SubElement(root, "property")
+        name = ET.SubElement(root, "name")
+        val = ET.SubElement(root, "value")
+        name.text, val.text = k, props[k]
+    return doc
 
 def main(argv):
-    assert len(argv) > 2 and not (len(argv) & 0x01)
+    assert len(argv) >= 2 and not (len(argv) & 0x01)
     conf_input = argv[0]
     conf_output = argv[1]
     nprops = len(argv[2:]) // 2
-    with open(conf_input, 'rb') as f:
-        data = f.read()
-    for i in range(nprops):
-        k, v = argv[2 + 2 * i], argv[3 + 2 * i]
-        data = add_replace(data, k, v)
+    doc = ET.parse(conf_input)
+    props = doc_to_dict(doc)
+    ndoc = dict_to_doc(props)
     with open(conf_output, 'wb') as f:
-        f.write(data)
-
+        f.write(ET.tostring(doc,
+                encoding="utf-8",                                
+                xml_declaration=True))
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/dev_tools/edit_conf
+++ b/dev_tools/edit_conf
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+"""
+An utility to edit hadoop configuration files.
+
+Usage::
+
+  $ edit_conf conf/yarn-site.xml tmp.xml \
+       yarn.nodemanager.resource.cpu-vcores 2 \
+       yarn.nodemanager.resource.memory-mb 1024
+
+"""
+
+from lxml import etree
+import sys
+
+
+def add_replace(data, key, value):
+    root = etree.fromstring(data)
+    found = False
+    for p in root.findall('property'):
+        if p.find('name').text == key:
+            p.find('value').text = value
+            found = True
+    if not found:
+        p = etree.SubElement(root, "property")
+        name = etree.SubElement(p, "name")
+        val = etree.SubElement(p, "value")
+        name.text, val.text = key, value
+    return etree.tostring(root, pretty_print=True)
+
+
+def main(argv):
+    assert len(argv) > 2 and not (len(argv) & 0x01)
+    conf_input = argv[0]
+    conf_output = argv[1]
+    nprops = len(argv[2:]) // 2
+    with open(conf_input, 'rb') as f:
+        data = f.read()
+    for i in range(nprops):
+        k, v = argv[2 + 2 * i], argv[3 + 2 * i]
+        data = add_replace(data, k, v)
+    with open(conf_output, 'wb') as f:
+        f.write(data)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
Added support to run development docker images on machines that require explicit hadoop configuration. 

It appears that sometimes -- well, at least on my laptop -- the jvm used in crs4/ansible-hadoop is not able to gather information on the container capabilities and thus misconfigures hadoop components, typically the nodemanager. 
This PR  allows the explicit setting of hadoop configuration properties when launching the crs4/pydoop docker image. 

In principle, most of this could be pushed to crs4/ansible-hadoop with the new configuration parameters passed via environment variables.