### PR TITLE
Core HDFS extension: explicitly initialize variables

### DIFF
--- a/src/native_core_hdfs/hdfs_file.cc
+++ b/src/native_core_hdfs/hdfs_file.cc
@@ -25,7 +25,7 @@
 
 PyObject* FileClass_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    FileInfo *self;
+    FileInfo *self = NULL;
 
     self = (FileInfo *)type->tp_alloc(type, 0);
     if (self != NULL) {
@@ -58,7 +58,7 @@ void FileClass_dealloc(FileInfo* self)
 
 int FileClass_init(FileInfo *self, PyObject *args, PyObject *kwds)
 {
-    PyObject *name = NULL, *mode = NULL, *tmp;
+    PyObject *name = NULL, *mode = NULL, *tmp = NULL;
 
     if (!PyArg_ParseTuple(args, "OOOO",
                           &(self->fs), &(self->file), &name, &mode)) {
@@ -275,7 +275,7 @@ static PyObject* _pread_new_pybuf(FileInfo* self, Py_ssize_t pos, Py_ssize_t nby
 
 PyObject* FileClass_read(FileInfo *self, PyObject *args, PyObject *kwds){
 
-    Py_ssize_t nbytes;
+    Py_ssize_t nbytes = 0;
 
     if (!_ensure_open_for_reading(self))
         return NULL;
@@ -298,7 +298,7 @@ PyObject* FileClass_read(FileInfo *self, PyObject *args, PyObject *kwds){
 
 PyObject* FileClass_read_chunk(FileInfo *self, PyObject *args, PyObject *kwds){
 
-    Py_buffer buffer;
+    Py_buffer buffer = {NULL, NULL};
 
     if (!_ensure_open_for_reading(self))
         return NULL;
@@ -318,8 +318,8 @@ PyObject* FileClass_read_chunk(FileInfo *self, PyObject *args, PyObject *kwds){
 
 PyObject* FileClass_pread(FileInfo *self, PyObject *args, PyObject *kwds){
 
-    Py_ssize_t position;
-    Py_ssize_t nbytes;
+    Py_ssize_t position = 0;
+    Py_ssize_t nbytes = 0;
 
     if (!_ensure_open_for_reading(self))
         return NULL;
@@ -345,8 +345,8 @@ PyObject* FileClass_pread(FileInfo *self, PyObject *args, PyObject *kwds){
 
 PyObject* FileClass_pread_chunk(FileInfo *self, PyObject *args, PyObject *kwds){
 
-    Py_buffer buffer;
-    Py_ssize_t position;
+    Py_buffer buffer = {NULL, NULL};
+    Py_ssize_t position = 0;
 
     if (!_ensure_open_for_reading(self))
         return NULL;
@@ -374,7 +374,7 @@ PyObject* FileClass_pread_chunk(FileInfo *self, PyObject *args, PyObject *kwds){
 
 PyObject* FileClass_seek(FileInfo *self, PyObject *args, PyObject *kwds) {
 
-    tOffset position, curpos;
+    tOffset position = 0, curpos = 0;
     int whence = SEEK_SET;
 
     if (!PyArg_ParseTuple(args, "n|i", &position, &whence))
@@ -427,8 +427,8 @@ PyObject* FileClass_tell(FileInfo *self, PyObject *args, PyObject *kwds){
 
 
 PyObject* FileClass_write(FileInfo* self, PyObject *args, PyObject *kwds) {
-    PyObject *input;
-    Py_buffer buffer;
+    PyObject *input = NULL;
+    Py_buffer buffer = {NULL, NULL};
 
     if (!hdfsFileIsOpenForWrite(self->file)) {
         PyErr_SetString(PyExc_IOError, "not writable");

--- a/src/native_core_hdfs/hdfs_fs.cc
+++ b/src/native_core_hdfs/hdfs_fs.cc
@@ -32,17 +32,14 @@
 
 PyObject* FsClass_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    FsInfo *self;
+    FsInfo *self = NULL;
 
     self = (FsInfo *)type->tp_alloc(type, 0);
     if (self != NULL) {
-
         self->host = NULL;
         self->port = 0;
-
         self->user = NULL;
         self->group = NULL;
-
         self->_fs = NULL;
     }
 
@@ -127,7 +124,7 @@ PyObject* FsClass_get_path_info(FsInfo* self, PyObject *args, PyObject *kwds) {
 
     char* path = NULL;
     PyObject* retval = NULL;
-    hdfsFileInfo* info;
+    hdfsFileInfo* info = NULL;
 
     if (!PyArg_ParseTuple(args, "es", "utf-8",  &path)) {
         return NULL;
@@ -169,7 +166,7 @@ PyObject* FsClass_get_path_info(FsInfo* self, PyObject *args, PyObject *kwds) {
 
 PyObject* FsClass_get_hosts(FsInfo* self, PyObject *args, PyObject *kwds) {
 
-    Py_ssize_t start, length;
+    Py_ssize_t start = 0, length = 0;
     PyObject* result = NULL;
     char* path = NULL;
     char*** hosts = NULL;
@@ -234,7 +231,6 @@ PyObject* FsClass_get_default_block_size(FsInfo* self) {
 }
 
 PyObject* FsClass_get_used(FsInfo* self) {
-
     tOffset size = hdfsGetUsed(self->_fs);
     return PyLong_FromSsize_t(size);
 }
@@ -242,8 +238,8 @@ PyObject* FsClass_get_used(FsInfo* self) {
 PyObject* FsClass_set_replication(FsInfo* self, PyObject* args, PyObject* kwds) {
 
     char* path = NULL;
-    short replication;
-    int result;
+    short replication = 0;
+    int result = 0;
 
     if (!PyArg_ParseTuple(args, "esh", "utf-8", &path, &replication))
         return NULL;
@@ -268,7 +264,7 @@ PyObject* FsClass_set_replication(FsInfo* self, PyObject* args, PyObject* kwds) 
 PyObject* FsClass_set_working_directory(FsInfo* self, PyObject* args, PyObject* kwds) {
 
     char* path = NULL;
-    int result;
+    int result = 0;
 
     if (!PyArg_ParseTuple(args, "es", "utf-8", &path))
         return NULL;
@@ -406,9 +402,9 @@ PyObject *FsClass_get_capacity(FsInfo *self) {
 
 PyObject* FsClass_copy(FsInfo* self, PyObject *args, PyObject *kwds)
 {
-    FsInfo* to_hdfs;
+    FsInfo* to_hdfs = NULL;
     char *from_path = NULL, *to_path = NULL;
-    int result;
+    int result = 0;
 
     if (! PyArg_ParseTuple(args, "esOes", "utf-8", &from_path,
                 &to_hdfs, "utf-8", &to_path)) {
@@ -437,7 +433,7 @@ PyObject* FsClass_copy(FsInfo* self, PyObject *args, PyObject *kwds)
 PyObject *FsClass_exists(FsInfo *self, PyObject *args, PyObject *kwds) {
 
     char* path = NULL;
-    int result;
+    int result = 0;
 
     if (! PyArg_ParseTuple(args, "es", "utf-8", &path))
         return NULL;
@@ -468,7 +464,7 @@ PyObject *FsClass_exists(FsInfo *self, PyObject *args, PyObject *kwds) {
 PyObject *FsClass_create_directory(FsInfo *self, PyObject *args, PyObject *kwds) {
 
     char* path = NULL;
-    int result;
+    int result = 0;
 
     if (! PyArg_ParseTuple(args, "es", "utf-8", &path)) {
         return NULL;
@@ -551,10 +547,8 @@ static int setPathInfo(PyObject* dict, hdfsFileInfo* fileInfo) {
 }
 
 PyObject *FsClass_list_directory(FsInfo *self, PyObject *args, PyObject *kwds) {
-
     PyObject* retval = NULL;
     char* path = NULL;
-
     hdfsFileInfo* pathList = NULL;
     int numEntries = 0;
     hdfsFileInfo* pathInfo = NULL;
@@ -633,9 +627,9 @@ done:
 
 PyObject *FsClass_move(FsInfo *self, PyObject *args, PyObject *kwds) {
 
-    FsInfo* to_hdfs;
+    FsInfo* to_hdfs = NULL;
     char *from_path = NULL, *to_path = NULL;
-    int result;
+    int result = 0;
 
     if (! PyArg_ParseTuple(args, "esOes", "utf-8", &from_path,
                 &to_hdfs, "utf-8", &to_path)) {
@@ -665,7 +659,7 @@ PyObject *FsClass_move(FsInfo *self, PyObject *args, PyObject *kwds) {
 PyObject *FsClass_rename(FsInfo *self, PyObject *args, PyObject *kwds) {
 
     char *from_path = NULL, *to_path = NULL;
-    int result;
+    int result = 0;
 
     if (! PyArg_ParseTuple(args, "eses", "utf-8", &from_path, "utf-8", &to_path))
         return NULL;
@@ -693,7 +687,7 @@ PyObject *FsClass_delete(FsInfo *self, PyObject *args, PyObject *kwds) {
 
     char* path = NULL;
     int recursive = 1;
-    int result;
+    int result = 0;
 
     if (!PyArg_ParseTuple(args, "es|i", "utf-8", &path, &recursive)) {
         return NULL;
@@ -721,7 +715,7 @@ PyObject *FsClass_chmod(FsInfo *self, PyObject *args, PyObject *kwds) {
 
     char* path = NULL;
     short mode = 1;
-    int result;
+    int result = 0;
 
     if (!PyArg_ParseTuple(args, "esh", "utf-8", &path, &mode)) {
         return NULL;
@@ -760,8 +754,8 @@ PyObject *FsClass_chmod(FsInfo *self, PyObject *args, PyObject *kwds) {
 PyObject *FsClass_chown(FsInfo *self, PyObject *args, PyObject *kwds) {
 
     char *path = NULL, *input_user = NULL, *input_group = NULL;
-    int result;
-    hdfsFileInfo* fileInfo;
+    int result = 0;
+    hdfsFileInfo* fileInfo = NULL;
 
     if (! PyArg_ParseTuple(args, "es|eses",
                 "utf-8", &path, "utf-8", &input_user, "utf-8", &input_group)) {
@@ -802,8 +796,8 @@ PyObject *FsClass_chown(FsInfo *self, PyObject *args, PyObject *kwds) {
 PyObject *FsClass_utime(FsInfo *self, PyObject *args, PyObject *kwds) {
 
     char* path = NULL;
-    tTime mtime, atime;
-    int result;
+    tTime mtime = 0, atime = 0;
+    int result = 0;
 
     if (! PyArg_ParseTuple(args, "esll", "utf-8", &path, &mtime, &atime)) {
         return NULL;

--- a/src/native_core_hdfs/hdfs_fs.cc
+++ b/src/native_core_hdfs/hdfs_fs.cc
@@ -295,11 +295,13 @@ PyObject* FsClass_open_file(FsInfo* self, PyObject *args, PyObject *kwds)
     PyObject* retval = NULL;
     char* path = NULL;
     const char* mode = MODE_READ;
-    int flags, buff_size, blocksize;
-    short replication;
-    hdfsFile file;
+    int flags = 0;
+    int buff_size = 0;
+    int blocksize = 0;
+    short replication = 0;
+    hdfsFile file = NULL;
     tOffset size = 0;
-    hdfsFileInfo* info;
+    hdfsFileInfo* info = NULL;
 
     if (!PyArg_ParseTuple(args, "es|sihi",
                           "utf-8", &path, &mode, &buff_size, &replication,

--- a/test/hdfs/all_tests.py
+++ b/test/hdfs/all_tests.py
@@ -21,6 +21,7 @@ from pydoop.test_utils import get_module
 
 
 TEST_MODULE_NAMES = [
+    'test_core',
     'test_local_fs',
     'test_hdfs_fs',
     'test_path',

--- a/test/hdfs/test_core.py
+++ b/test/hdfs/test_core.py
@@ -1,0 +1,51 @@
+# BEGIN_COPYRIGHT
+#
+# Copyright 2009-2018 CRS4.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# END_COPYRIGHT
+
+import unittest
+import uuid
+
+from pydoop.hdfs.core import init
+hdfs = init()
+
+
+class TestCore(unittest.TestCase):
+
+    def test_default(self):
+        path = "/tmp/pydoop-test-{}".format(uuid.uuid4().hex)
+        fs = f = None
+        try:
+            fs = hdfs.CoreHdfsFs("default", 0)
+            f = fs.open_file(path, "w")
+            f.write(b"bar\n")
+        finally:
+            if f:
+                f.close()
+                fs.delete(path)
+            if fs:
+                fs.close()
+
+
+def suite():
+    suite_ = unittest.TestSuite()
+    suite_.addTest(TestCore('test_default'))
+    return suite_
+
+
+if __name__ == '__main__':
+    _RUNNER = unittest.TextTestRunner(verbosity=2)
+    _RUNNER.run((suite()))


### PR DESCRIPTION
Fixes #309.

One possible cause for #309 is that at some point we changed some parameters from required to optional, so their initialization stopped being guaranteed by the Python-side value. To avoid situations like this in the future, ef9dd48 paranoically initializes variables everywhere.