### PR TITLE
Submitter: add check for bad upload files

### DIFF
--- a/pydoop/app/submit.py
+++ b/pydoop/app/submit.py
@@ -99,6 +99,9 @@ class PydoopSubmitter(object):
                                 for e in upload_and_cache)
             ]
             self.files_to_upload += upf_to_cache
+            for t in self.files_to_upload:
+                if not hdfs.path.isfile(t[0]):
+                    raise RuntimeError("not a file: %r" % (t[0]))
             cached_files = ["%s#%s" % (h, b) for (_, h, b) in upf_to_cache]
             cfiles += cached_files
         self.properties[prop] = ','.join(cfiles)
@@ -441,8 +444,8 @@ def add_parser_common_arguments(parser):
         help='Set a Hadoop property, e.g., -D mapred.compress.map.output=true'
     )
     parser.add_argument(
-        '--python-zip', metavar='ZIP_FILE', type=str, action="append",
-        help="Additional python zip file"
+        '--python-zip', metavar='ZIP_FILE', type=a_file_that_can_be_read,
+        action="append", help="Additional python zip file"
     )
     parser.add_argument(
         '--upload-file-to-cache', metavar='FILE', type=a_file_that_can_be_read,

--- a/test/app/test_submit.py
+++ b/test/app/test_submit.py
@@ -103,7 +103,6 @@ class TestAppSubmit(unittest.TestCase):
                    ("--input-format", 'mapreduce.lib.input.TextInputFormat'),
                    ("--output-format", 'mapreduce.lib.input.TextOutputFormat'),
                    ("--num-reducers", 10),
-                   ("--python-zip", 'allmymodules.zip'),
                    )
         try:
             with open(conf_file, 'w') as cf:
@@ -231,6 +230,11 @@ class TestAppSubmit(unittest.TestCase):
         self.assertEquals('value1', d['var1'])
         self.assertEquals('value2', d['var2'])
         self.assertEquals('str with = sign', d['var3'])
+
+    def test_bad_upload_files(self):
+        args = self._gen_default_args()
+        args.python_zip = [""]
+        self.assertRaises(Exception, self.submitter.set_args, args)
 
 
 def suite():


### PR DESCRIPTION
Fixes #312.

Note that the `--python-zip` type change does not protect against args passed via `set_args`, hence the additional check in `__set_files_to_cache_helper`.