### PR TITLE
Fix early timeout

### DIFF
--- a/.travis/run_checks
+++ b/.travis/run_checks
@@ -9,6 +9,8 @@ docker exec pydoop bash -c \
 docker exec pydoop bash -c \
   "source /etc/profile && cd test/avro && ${PYTHON} all_tests.py"
 docker exec -e PYTHON="${PYTHON}" -e DEBUG="${DEBUG:-}" pydoop bash -c \
+  "source /etc/profile && cd int_test && ./run_all"
+docker exec -e PYTHON="${PYTHON}" -e DEBUG="${DEBUG:-}" pydoop bash -c \
   "source /etc/profile && cd examples && ./run_all"
 docker exec -e PYTHON="${PYTHON}" -e DEBUG="${DEBUG:-}" pydoop bash -c \
   "source /etc/profile && cd examples/avro && ./run"

--- a/dev_tools/mapred_pipes
+++ b/dev_tools/mapred_pipes
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Set up the layout needed to build the "mapred" version of pipes
+
+set -euo pipefail
+this="${BASH_SOURCE-$0}"
+this_dir=$(cd -P -- "$(dirname -- "${this}")" && pwd -P)
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 HADOOP_SRC"
+    exit 1
+fi
+if [ ! -d "${1}"/hadoop-mapreduce-project ]; then
+    echo "ERROR: \"$1\" does not look like a Hadoop source dir"
+    exit 1
+fi
+hadoop_src=${1}
+
+pushd "${this_dir}/.."
+mapred_pipes_dir=src/it/crs4/pydoop/mapred/pipes
+rm -rf "${mapred_pipes_dir}"
+mkdir -p "${mapred_pipes_dir}"
+cp -rf "${hadoop_src}"/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapred/pipes/* "${mapred_pipes_dir}"/
+sed -i 's/package org\.apache\.hadoop/package it\.crs4\.pydoop/g' "${mapred_pipes_dir}"/*
+
+# not exactly future-proof
+sed_cmd="s|self\.java_files = |self\.java_files = glob.glob(\"${mapred_pipes_dir}/*.java\") + |"
+sed -i "${sed_cmd}" setup.py
+popd

--- a/int_test/config.sh
+++ b/int_test/config.sh
@@ -1,0 +1,21 @@
+[ -n "${PYDOOP_INT_TESTS:-}" ] && return || readonly PYDOOP_INT_TESTS=1
+
+die() {
+    echo $1 1>&2
+    exit 1
+}
+
+export USER="${USER:-$(whoami)}"
+export HADOOP="${HADOOP:-hadoop}"
+export HDFS="${HDFS:-hdfs}"
+export MAPRED="${MAPRED:-mapred}"
+export YARN="${YARN:-yarn}"
+export PYTHON="${PYTHON:-python}"
+export PY_VER=$("${PYTHON}" -c 'import sys; print(sys.version_info[0])')
+export PYDOOP="pydoop${PY_VER}"
+
+ensure_dfs_home() {
+    ${HDFS} dfs -mkdir -p /user/${USER}
+}
+
+export -f die ensure_dfs_home

--- a/int_test/progress/mrapp.py
+++ b/int_test/progress/mrapp.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+# BEGIN_COPYRIGHT
+#
+# Copyright 2009-2018 CRS4.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# END_COPYRIGHT
+import sys
+import time
+
+import pydoop.mapreduce.api as api
+import pydoop.mapreduce.pipes as pipes
+import pydoop.hdfs as hdfs
+
+
+class Mapper(api.Mapper):
+
+    def map(self, context):
+        time.sleep(1)
+        sys.stderr.write("processing: %r\n" % (context.value,))
+        context.emit(context.key, len(context.value))
+
+
+class Writer(api.RecordWriter):
+
+    def __init__(self, context):
+        super(Writer, self).__init__(context)
+        jc = context.job_conf
+        outfn = context.get_default_work_file()
+        hdfs_user = jc.get("pydoop.hdfs.user", None)
+        self.file = hdfs.open(outfn, "wt", user=hdfs_user)
+        self.sep = jc.get("mapreduce.output.textoutputformat.separator", "\t")
+
+    def close(self):
+        self.file.close()
+
+    def emit(self, key, value):
+        self.file.write(str(key) + self.sep + str(value) + "\n")
+
+
+FACTORY = pipes.Factory(mapper_class=Mapper, record_writer_class=Writer)
+
+
+def __main__():
+    pipes.run_task(FACTORY)

--- a/int_test/progress/run
+++ b/int_test/progress/run
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# BEGIN_COPYRIGHT
+#
+# Copyright 2009-2018 CRS4.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# END_COPYRIGHT
+
+set -euo pipefail
+[ -n "${DEBUG:-}" ] && set -x
+this="${BASH_SOURCE-$0}"
+this_dir=$(cd -P -- "$(dirname -- "${this}")" && pwd -P)
+. "${this_dir}/../config.sh"
+
+MODULE="mrapp"
+TIMEOUT_SECS=10
+N_LINES=$((5 * TIMEOUT_SECS))
+OPTS=(
+    "-D" "mapreduce.task.timeout=$((1000 * TIMEOUT_SECS))"
+    "-D" "mapreduce.job.maps=1"
+    "--python-program" "${PYTHON}"
+    "--job-name" "${MODULE}"
+    "--num-reducers" "0"
+    "--upload-file-to-cache" "${this_dir}/${MODULE}.py"
+    "--do-not-use-java-record-writer"
+)
+[ -n "${DEBUG:-}" ] && OPTS+=( "--log-level" "DEBUG" )
+
+WD=$(mktemp -d)
+DATA="${WD}"/${RANDOM}
+for i in $(seq 1 ${N_LINES}); do
+    echo "foobar_${i}" >> "${DATA}"
+done
+INPUT=$(basename ${DATA})_in
+OUTPUT=$(basename ${DATA})_out
+
+ensure_dfs_home
+${HDFS} dfs -rm -r -f "${INPUT}" "${OUTPUT}"
+${HDFS} dfs -put "${DATA}" "${INPUT}"
+${PYDOOP} submit "${OPTS[@]}" ${MODULE} "${INPUT}" "${OUTPUT}"
+
+${HDFS} dfs -test -e "${OUTPUT}"/part-m-00000
+rm -rf "${WD}"

--- a/int_test/run_all
+++ b/int_test/run_all
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# BEGIN_COPYRIGHT
+#
+# Copyright 2009-2018 CRS4.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# END_COPYRIGHT
+
+set -euo pipefail
+
+this="${BASH_SOURCE-$0}"
+this_dir=$(cd -P -- "$(dirname -- "${this}")" && pwd -P)
+. "${this_dir}/config.sh"
+
+tests=(
+    progress
+)
+
+for e in ${tests[@]}; do
+    pushd "${this_dir}/${e}"
+    ./run
+    popd
+done

--- a/src/it/crs4/pydoop/mapreduce/pipes/OutputHandler.java
+++ b/src/it/crs4/pydoop/mapreduce/pipes/OutputHandler.java
@@ -95,11 +95,11 @@ class OutputHandler<K extends WritableComparable, V extends Writable>
      */
     @Override
     public void progress(float progress) throws IOException {
+        progressValue = progress;
+        context.progress();
         if (recordReader != null) {
             progressKey.set(progress);
             recordReader.next(progressKey, nullValue);
-        } else { // FIXME --- Are we sure?
-            progressValue = progress;
         }
     }
 


### PR DESCRIPTION
Fixes #321.

The fix is all in `OutputHandler.java`. The rest is a new integration test that triggers the bug (see https://travis-ci.org/simleo/pydoop/builds/408558108) and a quick dev hack to build a `mapred` version of our submitter (mostly for debugging purposes).