### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/docs/how_to_cite.rst
+++ b/docs/how_to_cite.rst
@@ -4,7 +4,7 @@ How to Cite
 Pydoop is developed and maintained by researchers at `CRS4
 <http://www.crs4.it>`_ -- Distributed Computing group.  If you use
 Pydoop as part of your research work, please cite `the HPDC 2010 paper
-<http://dx.doi.org/10.1145/1851476.1851594>`_.
+<https://doi.org/10.1145/1851476.1851594>`_.
 
 **Plain text**::
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -26,6 +26,6 @@ knowledge, is not available in other solutions.
 
 .. [#pydoop] Simone Leo, Gianluigi Zanetti. `Pydoop: a Python
    MapReduce and HDFS API for Hadoop.
-   <http://dx.doi.org/10.1145/1851476.1851594>`_, Proceedings Of The
+   <https://doi.org/10.1145/1851476.1851594>`_, Proceedings Of The
    19th ACM International Symposium On High Performance Distributed
    Computing, page 819--825, 2010


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

I'd simply like to suggest to update all static DOI links accordingly.

Cheers!