### PR TITLE
Fix flake8 errors

### DIFF
--- a/examples/pydoop_script/scripts/wordcount_sw.py
+++ b/examples/pydoop_script/scripts/wordcount_sw.py
@@ -26,7 +26,7 @@ STOP_WORDS_FN = 'stop_words.txt'
 try:
     with open(STOP_WORDS_FN) as f:
         STOP_WORDS = frozenset(l.strip() for l in f if not l.isspace())
-except OSError as e:
+except OSError:
     STOP_WORDS = frozenset()
 
 

--- a/pydoop/avrolib.py
+++ b/pydoop/avrolib.py
@@ -61,12 +61,12 @@ class Serializer(object):
 
 try:
     from pyavroc import AvroDeserializer
-except ImportError as e:
+except ImportError:
     AvroDeserializer = Deserializer
 
 try:
     from pyavroc import AvroSerializer
-except ImportError as e:
+except ImportError:
     AvroSerializer = Serializer
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E402
+ignore = E402,W504
 exclude = hadoop*,build


### PR DESCRIPTION
Fixes #332.

Re: line breaking around operators, my understanding is that now both warnings are active, and you have to choose which convention to adhere to (see PyCQA/pycodestyle#498), so I have just silenced the warning for the convention we're not using.