### PR TITLE
Local mode install

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.*
+Dockerfile*
+docker

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,0 +1,12 @@
+FROM crs4/pydoop-client-base
+MAINTAINER simone.leo@crs4.it
+
+COPY . /build/pydoop
+WORKDIR /build/pydoop
+
+RUN for v in 2 3; do \
+      pip${v} install --no-cache-dir --upgrade -r requirements.txt && \
+      python${v} setup.py build && \
+      python${v} setup.py install --skip-build && \
+      python${v} setup.py clean; \
+    done

--- a/docker/Dockerfile.client-base
+++ b/docker/Dockerfile.client-base
@@ -1,0 +1,33 @@
+FROM centos:7
+MAINTAINER simone.leo@crs4.it
+
+ARG HADOOP_VERSION=3.0.3
+ARG JAVA_VERSION=1.8.0
+
+ENV HADOOP_HOME=/opt/hadoop
+ENV JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-openjdk
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+
+COPY install_hadoop.sh /
+
+RUN echo "assumeyes=1" >> /etc/yum.conf && \
+    yum install https://centos7.iuscommunity.org/ius-release.rpm && \
+    yum update && \
+    yum install \
+      java-${JAVA_VERSION}-openjdk-devel \
+      gcc \
+      gcc-c++ \
+      python-devel \
+      python-pip \
+      python36u-devel \
+      python36u-pip && \
+    yum clean all && \
+    bash /install_hadoop.sh && \
+    echo "export JAVA_HOME=\"/usr/lib/jvm/java-${JAVA_VERSION}-openjdk\"" > /etc/profile.d/java.sh && \
+    echo "export PATH=\"${HADOOP_HOME}/bin:${HADOOP_HOME}/sbin:${PATH}\"" > /etc/profile.d/hadoop.sh && \
+    ln -rs /usr/bin/python3.6 /usr/bin/python3 && \
+    ln -rs /usr/bin/pip3.6 /usr/bin/pip3 && \
+    for v in 2 3; do \
+      pip${v} install --no-cache-dir --upgrade pip; \
+    done

--- a/docker/Dockerfile.client-base
+++ b/docker/Dockerfile.client-base
@@ -18,6 +18,7 @@ RUN echo "assumeyes=1" >> /etc/yum.conf && \
       java-${JAVA_VERSION}-openjdk-devel \
       gcc \
       gcc-c++ \
+      make \
       python-devel \
       python-pip \
       python36u-devel \

--- a/docker/install_hadoop.sh
+++ b/docker/install_hadoop.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tar="hadoop-${HADOOP_VERSION}.tar.gz"
+repo="http://www-eu.apache.org/dist/hadoop/common"
+
+mkdir -p "${HADOOP_HOME}"
+wd=$(mktemp -d)
+pushd "${wd}"
+curl ${repo}/hadoop-${HADOOP_VERSION}/${tar} | tar xz
+mv hadoop-${HADOOP_VERSION}/* "${HADOOP_HOME}"
+popd
+rm -rf "${wd}"

--- a/int_test/mapred_submitter/run_app.sh
+++ b/int_test/mapred_submitter/run_app.sh
@@ -29,6 +29,11 @@ pushd "${this_dir}"
 [ $# -ge 1 ] || die "Usage: $0 APP_NAME"
 name=$1
 
+${PYTHON} -c "import pydoop
+if pydoop.hadoop_version_info().is_local():
+    raise pydoop.LocalModeNotSupported()
+"
+
 opts=(
     "-D" "mapreduce.job.name=${name}"
     "-D" "mapreduce.task.timeout=10000"

--- a/setup.py
+++ b/setup.py
@@ -324,11 +324,6 @@ class BuildPydoop(build):
     def run(self):
         if HADOOP_VERSION_INFO.tuple < (2,):
             raise RuntimeError('Hadoop v1 is not supported')
-        # `is_local` requires running the local hadoop executable.
-        # Don't move this call into other methods of the class that
-        # may be called while executing other commands (e.g., clean)
-        if HADOOP_VERSION_INFO.is_local():
-            raise pydoop.LocalModeNotSupported()
         write_version()
         write_config()
         shutil.copyfile(PROP_FN, os.path.join("pydoop", PROP_BN))


### PR DESCRIPTION
Fixes #329.

This is a partial revert of #194 that removes the no-[local-mode](https://hadoop.apache.org/docs/r3.0.3/hadoop-project-dist/hadoop-common/SingleCluster.html#Standalone_Operation) constraint at build time only.

`mapred pipes` does not support local mode. Indeed, the `NullPointerException` mentioned in #181 is still unhandled in recent Hadoop versions. However, checking for local mode at build time is neither necessary (we only need YARN to be configured at run time) nor useful (the configuration might change to local mode after the build).

This PR includes a new Docker setup to quickly check what happens in local mode:

```bash
docker run --rm -it crs4/pydoop-client bash -l
```
```
cd int_test/mapred_submitter
mapred pipes -program ${PWD}/mr/map_reduce_java_rw.py -input ${PWD}/input/map_reduce -output /tmp/junk
...
2019-01-21 11:06:24,141 WARN mapred.LocalJobRunner: job_local939509594_0001
java.lang.Exception: java.lang.NullPointerException
	at org.apache.hadoop.mapred.LocalJobRunner$Job.runTasks(LocalJobRunner.java:492)
	at org.apache.hadoop.mapred.LocalJobRunner$Job.run(LocalJobRunner.java:552)
Caused by: java.lang.NullPointerException
	at org.apache.hadoop.mapred.pipes.Application.<init>(Application.java:105)
...
```

Note that the exception is thrown within the `pipes` package. This means that, while we don't control `mapred pipes`, we might be able to do something about it in our own submitter, so we still don't have a final answer to #330.

A nice effect of this change is that now it's much easier to create a Pydoop-enabled Docker image, since a working Hadoop conf dir can be provided (e.g., as a volume) at run time.