### PR TITLE
Loosen setup requirements

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -71,18 +71,17 @@ Environment Setup
 -----------------
 
 Pydoop needs to know where the JDK and Hadoop are installed on your
-system. This is done by exporting, respectively, the ``JAVA_HOME`` and
-``HADOOP_HOME`` environment variables. For instance::
+system. Although it will try to guess both locations, you can help by
+exporting, respectively, the ``JAVA_HOME`` and ``HADOOP_HOME`` environment
+variables. For instance::
 
   export HADOOP_HOME="/opt/hadoop-3.0.1"
   export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
 
-If you don't know where your JDK is, find the path of the ``java`` executable::
-
-  $ readlink -f $(which java)
-  /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
-
-Then strip the trailing ``/jre/bin/java`` to get the ``JAVA_HOME``.
+Note that Pydoop is interested in the **JDK** home (where ``include/jni.h``
+can be found), not the JRE home. Depending on your Java distribution and
+version, these can be different directories (usually the former being the
+latter's parent).
 
 
 Building and Installing
@@ -115,8 +114,7 @@ additional info.
 Troubleshooting
 ---------------
 
-#. "java home not found" error, with ``JAVA_HOME`` properly exported: try
-   setting ``JAVA_HOME`` in ``hadoop-env.sh``
+#. "java home not found" error: try setting ``JAVA_HOME`` in ``hadoop-env.sh``
 
 #. "libjvm.so not found" error: try the following::
 

--- a/pydoop/hdfs/fs.py
+++ b/pydoop/hdfs/fs.py
@@ -287,7 +287,7 @@ class hdfs(object):
         :return: filesystem capacity
         """
         _complain_ifclosed(self.closed)
-        if self.__status.host is '':
+        if not self.__status.host:
             raise RuntimeError('Capacity is not defined for a local fs')
         return self.fs.get_capacity()
 

--- a/pydoop/utils/jvm.py
+++ b/pydoop/utils/jvm.py
@@ -55,8 +55,10 @@ def get_java_home():
             f.write(JPROG.substitute(classname=jclass))
         try:
             subprocess.check_call(["javac", jsrc])
-            path = subprocess.check_output(["java", "-cp", wd, jclass])
-        except (OSError, subprocess.CalledProcessError):
+            path = subprocess.check_output(
+                ["java", "-cp", wd, jclass], universal_newlines=True
+            )
+        except (OSError, UnicodeDecodeError, subprocess.CalledProcessError):
             raise error
         finally:
             shutil.rmtree(wd)

--- a/pydoop/utils/jvm.py
+++ b/pydoop/utils/jvm.py
@@ -17,15 +17,56 @@
 # END_COPYRIGHT
 
 import os
+import shutil
+import string
+import subprocess
 import sys
+import tempfile
 import fnmatch
 
 
+JPROG = string.Template("""\
+public class ${classname} {
+  public static void main(String[] args) {
+    System.out.println(System.getProperty("java.home"));
+  }
+}
+""")
+
+
 def get_java_home():
+    """\
+    Try getting JAVA_HOME from system properties.
+
+    We are interested in the JDK home, containing include/jni.h, while the
+    java.home property points to the JRE home. If a JDK is installed, however,
+    the two are (usually) related: the JDK home is either the same directory
+    as the JRE home (recent java versions) or its parent (and java.home points
+    to jdk_home/jre).
+    """
+    error = RuntimeError("java home not found, try setting JAVA_HOME")
     try:
         return os.environ["JAVA_HOME"]
     except KeyError:
-        raise RuntimeError("java home not found, try setting JAVA_HOME")
+        wd = tempfile.mkdtemp(prefix='pydoop_')
+        jclass = "Temp"
+        jsrc = os.path.join(wd, "%s.java" % jclass)
+        with open(jsrc, "w") as f:
+            f.write(JPROG.substitute(classname=jclass))
+        try:
+            subprocess.check_call(["javac", jsrc])
+            path = subprocess.check_output(["java", "-cp", wd, jclass])
+        except (OSError, subprocess.CalledProcessError):
+            raise error
+        finally:
+            shutil.rmtree(wd)
+        path = os.path.normpath(path.strip())
+        if os.path.exists(os.path.join(path, "include", "jni.h")):
+            return path
+        path = os.path.dirname(path)
+        if os.path.exists(os.path.join(path, "include", "jni.h")):
+            return path
+        raise error
 
 
 def load_jvm_lib(java_home=None):

--- a/setup.py
+++ b/setup.py
@@ -16,20 +16,17 @@
 #
 # END_COPYRIGHT
 
-"""
-Important environment variables
--------------------------------
+"""\
+Pydoop is a Python MapReduce and HDFS API for Hadoop.
 
-The Pydoop setup looks in a number of default paths for what it
-needs.  If necessary, you can override its behaviour or provide an
-alternative path by exporting the environment variables below::
+Pydoop is built on top of two C/C++ extension modules: a libhdfs wrapper and a
+(de)serialization library for types used by the Hadoop Pipes protocol. Since
+libhdfs is, in turn, a JNI wrapper for the HDFS Java code, Pydoop needs a JDK
+(a JRE is not enough) to build.
 
-  JAVA_HOME, e.g., /opt/sun-jdk
-  HADOOP_HOME, e.g., /opt/hadoop
-
-Other relevant environment variables include::
-
-  HADOOP_VERSION, e.g., 2.7.4 (override Hadoop's version string).
+You can point Pydoop to the Java home directory by exporting the JAVA_HOME
+environment variable. Make sure JAVA_HOME points to the JDK home directory
+(e.g., ${JAVA_HOME}/include/jni.h should be a valid path).
 """
 from __future__ import print_function
 
@@ -68,9 +65,6 @@ from distutils import log
 
 import pydoop
 import pydoop.utils.jvm as jvm
-
-HADOOP_HOME = pydoop.hadoop_home()
-HADOOP_VERSION_INFO = pydoop.hadoop_version_info()
 
 VERSION_FN = "VERSION"
 GIT_REV_FN = "GIT_REV"
@@ -216,8 +210,6 @@ class JavaBuilder(object):
         self.java_libs = [JavaLib()]
 
     def run(self):
-        log.info("hadoop_home: %r" % (HADOOP_HOME,))
-        log.info("hadoop_version: '%s'" % HADOOP_VERSION_INFO)
         for jlib in self.java_libs:
             self.__build_java_lib(jlib)
 
@@ -330,8 +322,6 @@ class BuildPydoop(build):
         shutil.rmtree(self.build_temp)
 
     def run(self):
-        if HADOOP_VERSION_INFO.tuple < (2,):
-            raise RuntimeError('Hadoop v1 is not supported')
         write_version()
         write_config()
         shutil.copyfile(PROP_FN, os.path.join("pydoop", PROP_BN))

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ libhdfs is, in turn, a JNI wrapper for the HDFS Java code, Pydoop needs a JDK
 
 You can point Pydoop to the Java home directory by exporting the JAVA_HOME
 environment variable. Make sure JAVA_HOME points to the JDK home directory
-(e.g., ${JAVA_HOME}/include/jni.h should be a valid path).
+(e.g., ${JAVA_HOME}/include/jni.h should be a valid path). If JAVA_HOME is not
+defined, Pydoop will try to get the JDK home from Java system properties.
 """
 from __future__ import print_function
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ os.environ['OPT'] = ' '.join(
 from setuptools import setup, find_packages, Extension
 from distutils.command.build import build
 from distutils.command.build_ext import build_ext
-from distutils.command.clean import clean
 from distutils.errors import DistutilsSetupError, CompileError
 from distutils import log
 
@@ -340,32 +339,6 @@ class BuildPydoop(build):
         log.info("Build finished")
 
 
-class Clean(clean):
-
-    def run(self):
-        clean.run(self)
-        garbage_list = [
-            "build",
-            "dist",
-            "pydoop.egg-info",
-            "pydoop/config.py",
-            "pydoop/version.py",
-            "examples/avro/java/target",
-            "examples/avro/java/project/project",
-            "examples/avro/java/project/target",
-            "examples/avro/py/to_from_avro",
-        ]
-        for p in garbage_list:
-            rm_rf(p, self.dry_run)
-        self._clean_examples()
-
-    @staticmethod
-    def _clean_examples():
-        for root, _, files in os.walk('examples'):
-            if 'Makefile' in files:
-                subprocess.call(["make", "-C", root, "clean"])
-
-
 setup(
     name="pydoop",
     version=get_version_string(),
@@ -387,7 +360,6 @@ setup(
     cmdclass={
         "build": BuildPydoop,
         "build_ext": BuildPydoopExt,
-        "clean": Clean
     },
     entry_points={'console_scripts': CONSOLE_SCRIPTS},
     platforms=["Linux"],

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,11 @@ You can point Pydoop to the Java home directory by exporting the JAVA_HOME
 environment variable. Make sure JAVA_HOME points to the JDK home directory
 (e.g., ${JAVA_HOME}/include/jni.h should be a valid path). If JAVA_HOME is not
 defined, Pydoop will try to get the JDK home from Java system properties.
+
+To compile its Java components, Pydoop also needs to know where Hadoop is. You
+can specify its location via the HADOOP_HOME environment variable. If
+HADOOP_HOME is not defined, Pydoop will try a few common locations before
+giving up.
 """
 from __future__ import print_function
 

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,8 @@ os.environ['OPT'] = ' '.join(
 )
 
 from setuptools import setup, find_packages, Extension
+from setuptools.command.build_ext import build_ext
 from distutils.command.build import build
-from distutils.command.build_ext import build_ext
 from distutils.errors import DistutilsSetupError, CompileError
 from distutils import log
 


### PR DESCRIPTION
Follow up to #337 that further loosens `setup.py` requirements.

* The `JAVA_HOME` env var is now optional: if it's not defined, we try to derive the JDK home from the `java.home` system property. If this fails for any reason, we fall back to asking for `JAVA_HOME` as we did before.
* All logic that requires Java home info has been moved to the build phase, allowing other setup commands to run with (almost) no requirements. For instance, we can now run `python setup.py sdist` from Travis.
* The `HADOOP_HOME` env var is now explicitly optional. In this case we already had auto-detection logic in place, but now the docs make it clear.