### PR TITLE
Delay HDFS unit tests

### DIFF
--- a/test/all_tests.py
+++ b/test/all_tests.py
@@ -23,9 +23,9 @@ import importlib
 
 _TEST_DIRS = (
     "app",
-    "hdfs",
-    "mapreduce",
     "common",
+    "mapreduce",
+    "hdfs",  # run these last, in case HDFS needs time to be fully up
 )
 
 


### PR DESCRIPTION
Several Travis jobs have been failing lately with errors like:

```
org.apache.hadoop.ipc.RemoteException(java.io.IOException): File /tmp/pydoop-test-1337ed0df8624e07975aebfdee4c5b97 could only be written to 0 of the 1 minReplication nodes. There are 1 datanode(s) running and 1 node(s) are excluded in this operation.
```

Although the message says the data node is running, this might be due to HDFS still being in a somewhat inconsistent state after the initial startup. This PR delays HDFS-related tests so that HDFS has a couple more seconds to stabilize.