### PR TITLE
Non-recursive hdfs rm

### DIFF
--- a/examples/hdfs/repl_session.py
+++ b/examples/hdfs/repl_session.py
@@ -48,8 +48,8 @@ if __name__ == "__main__":
     import os
     import pydoop.hdfs as hdfs
     try:
-        hdfs.rmr("test")
-        hdfs.rmr("test.copy")
+        hdfs.rm("test")
+        hdfs.rm("test.copy")
         os.remove("/tmp/hello.txt")
     except OSError:
         pass

--- a/pydoop/app/submit.py
+++ b/pydoop/app/submit.py
@@ -288,7 +288,7 @@ class PydoopSubmitter(object):
                 self.logger.debug(
                     "Removing temporary working directory %s", self.remote_wd
                 )
-                hdfs.rmr(self.remote_wd)
+                hdfs.rm(self.remote_wd)
             except IOError:
                 pass
 

--- a/pydoop/hadut.py
+++ b/pydoop/hadut.py
@@ -487,7 +487,7 @@ class PipesRunner(object):
         Remove the working directory, if any.
         """
         if self.wd:
-            hdfs.rmr(self.wd)
+            hdfs.rm(self.wd)
 
     def set_input(self, input_, put=False):
         """

--- a/pydoop/hdfs/__init__.py
+++ b/pydoop/hdfs/__init__.py
@@ -61,6 +61,7 @@ __all__ = [
     'put',
     'get',
     'mkdir',
+    'rm',
     'rmr',
     'lsl',
     'ls',
@@ -264,15 +265,23 @@ def mkdir(hdfs_path, user=None):
     return retval
 
 
-def rmr(hdfs_path, user=None):
+def rm(hdfs_path, recursive=True, user=None):
     """
-    Recursively remove files and directories.
+    Remove a file or directory.
+
+    If ``recursive`` is :obj:`True` (the default), directory contents are
+    removed recursively.
     """
     host, port, path_ = path.split(hdfs_path, user)
     fs = hdfs(host, port, user)
-    retval = fs.delete(path_)
+    retval = fs.delete(path_, recursive=recursive)
     fs.close()
     return retval
+
+
+# backwards compatibility
+def rmr(hdfs_path, user=None):
+    return rm(hdfs_path, recursive=True, user=user)
 
 
 def lsl(hdfs_path, user=None, recursive=False):

--- a/test/hdfs/test_hdfs.py
+++ b/test/hdfs/test_hdfs.py
@@ -175,7 +175,7 @@ class TestHDFS(unittest.TestCase):
             if t.kind == 0:
                 self.assertEqual(hdfs.load(exp_t.name), self.data)
         # check semantics when target dir already exists
-        hdfs.rmr(copy_on_wd)
+        hdfs.rm(copy_on_wd)
         hdfs.mkdir(copy_on_wd)
         hdfs.cp(src, copy_on_wd, mode="wb")
         exp_t = self.__make_tree(copy_on_wd, root=src_bn, create=False)
@@ -209,10 +209,10 @@ class TestHDFS(unittest.TestCase):
             rdata = fi.read()
         self.assertEqual(rdata, self.data)
 
-    def rmr(self):
+    def rm(self):
         for wd in self.local_wd, self.hdfs_wd:
             t1 = self.__make_tree(wd)
-            hdfs.rmr(t1.name)
+            hdfs.rm(t1.name)
             self.assertEqual(len(hdfs.ls(wd)), 0)
 
     def chmod(self):
@@ -360,7 +360,7 @@ class TestHDFS(unittest.TestCase):
         self.assertGreaterEqual(counter.count, acceptable_threshold)
 
         with counter:
-            hdfs.rmr(self.hdfs_paths[0] + '_2')
+            hdfs.rm(self.hdfs_paths[0] + '_2')
         self.assertGreaterEqual(counter.count, acceptable_threshold)
 
         # ...we could go on, but the better strategy would be to insert a check
@@ -378,7 +378,7 @@ def suite():
     suite_.addTest(TestHDFS("cp"))
     suite_.addTest(TestHDFS("put"))
     suite_.addTest(TestHDFS("get"))
-    suite_.addTest(TestHDFS("rmr"))
+    suite_.addTest(TestHDFS("rm"))
     suite_.addTest(TestHDFS("chmod"))
     suite_.addTest(TestHDFS("move"))
     suite_.addTest(TestHDFS("chown"))

--- a/test/hdfs/test_path.py
+++ b/test/hdfs/test_path.py
@@ -234,7 +234,7 @@ class TestExists(unittest.TestCase):
         for path in base_path, base_path + UNI_CHR:
             hdfs.dump("foo\n", path)
             self.assertTrue(hdfs.path.exists(path))
-            hdfs.rmr(path)
+            hdfs.rm(path)
             self.assertFalse(hdfs.path.exists(path))
 
 
@@ -250,12 +250,12 @@ class TestKind(unittest.TestCase):
             try:
                 hdfs.dump("foo\n", path)
                 self.assertEqual('file', hdfs.path.kind(path))
-                hdfs.rmr(path)
+                hdfs.rm(path)
                 hdfs.mkdir(path)
                 self.assertEqual('directory', hdfs.path.kind(path))
             finally:
                 try:
-                    hdfs.rmr(path)
+                    hdfs.rm(path)
                 except IOError:
                     pass
 
@@ -265,12 +265,12 @@ class TestKind(unittest.TestCase):
             try:
                 hdfs.dump("foo\n", path)
                 self.assertTrue(hdfs.path.isfile(path))
-                hdfs.rmr(path)
+                hdfs.rm(path)
                 hdfs.mkdir(path)
                 self.assertFalse(hdfs.path.isfile(path))
             finally:
                 try:
-                    hdfs.rmr(path)
+                    hdfs.rm(path)
                 except IOError:
                     pass
 
@@ -280,12 +280,12 @@ class TestKind(unittest.TestCase):
             try:
                 hdfs.dump("foo\n", path)
                 self.assertFalse(hdfs.path.isdir(path))
-                hdfs.rmr(path)
+                hdfs.rm(path)
                 hdfs.mkdir(path)
                 self.assertTrue(hdfs.path.isdir(path))
             finally:
                 try:
-                    hdfs.rmr(path)
+                    hdfs.rm(path)
                 except IOError:
                     pass
 
@@ -351,7 +351,7 @@ class TestStat(unittest.TestCase):
             self.assertEqual(attr, info[n2])
         self.__check_extra_args(s, info)
         self.__check_wrapper_funcs(p)
-        hdfs.rmr(p)
+        hdfs.rm(p)
 
     def stat_on_local(self):
         wd_ = tempfile.mkdtemp(prefix='pydoop_', suffix=UNI_CHR)
@@ -381,7 +381,7 @@ class TestStat(unittest.TestCase):
                     self.assertEqual(getattr(s, n), exp_v)
         self.__check_extra_args(s, info)
         self.__check_wrapper_funcs(p)
-        hdfs.rmr(wd)
+        hdfs.rm(wd)
 
     def stat_on_dir(self):
         s = hdfs.path.stat('/user/%s' % DEFAULT_USER)
@@ -418,7 +418,7 @@ class TestIsSomething(unittest.TestCase):
         link = os.path.join(wd_, make_random_str())
         os.symlink(wd_, link)
         self.assertTrue(hdfs.path.islink('file:%s' % link))
-        hdfs.rmr(wd)
+        hdfs.rm(wd)
 
     def ismount(self):
         self.assertFalse(hdfs.path.ismount('hdfs://host:1/foo'))
@@ -443,7 +443,7 @@ class TestReal(unittest.TestCase):
         os.symlink(wd_, link)
         expected_path = 'file:%s' % os.path.realpath(wd_)
         self.assertEqual(hdfs.path.realpath('file:%s' % link), expected_path)
-        hdfs.rmr(wd)
+        hdfs.rm(wd)
 
 
 class TestSame(unittest.TestCase):
@@ -454,13 +454,13 @@ class TestSame(unittest.TestCase):
         link = os.path.join(wd_, make_random_str())
         os.symlink(wd_, link)
         self.assertTrue(hdfs.path.samefile('file:%s' % link, 'file:%s' % wd_))
-        hdfs.rmr(wd)
+        hdfs.rm(wd)
 
     def samefile_rel(self):
         p = make_random_str() + UNI_CHR
         hdfs.dump("foo\n", p)
         self.assertTrue(hdfs.path.samefile(p, hdfs.path.abspath(p)))
-        hdfs.rmr(p)
+        hdfs.rm(p)
 
     def samefile_norm(self):
         for pre in '', 'file:/', 'hdfs://host:1/':
@@ -478,7 +478,7 @@ class TestAccess(unittest.TestCase):
         hdfs.mkdir(self.path)
 
     def tearDown(self):
-        hdfs.rmr(self.path)
+        hdfs.rm(self.path)
 
     # FIXME: far from exhaustive.  This is a slow test
     def __test(self, offset, user=None):
@@ -506,7 +506,7 @@ class TestUtime(unittest.TestCase):
         st = hdfs.path.stat(path)
         self.assertEqual(st.st_atime, new_atime)
         self.assertEqual(st.st_mtime, new_mtime)
-        hdfs.rmr(path)
+        hdfs.rm(path)
 
 
 class TestCallFromHdfs(unittest.TestCase):
@@ -516,7 +516,7 @@ class TestCallFromHdfs(unittest.TestCase):
         hdfs.dump("foo\n", self.path)
 
     def tearDown(self):
-        hdfs.rmr(self.path)
+        hdfs.rm(self.path)
 
     def test_stat(self):
         for name in 'stat', 'lstat':


### PR DESCRIPTION
Adds a new `hdfs.rm` that behaves like the underlying `delete`, i.e., with the option to raise an exception on a non-empty directory. `hdfs.rmr` is still in place, but it's been undocumented and it's not used anymore internally.