### PR TITLE
Single source externalsplits conf key in properties file

### DIFF
--- a/pydoop.properties
+++ b/pydoop.properties
@@ -4,3 +4,4 @@ AVRO_KEY_INPUT_SCHEMA=pydoop.mapreduce.avro.key.input.schema
 AVRO_KEY_OUTPUT_SCHEMA=pydoop.mapreduce.avro.key.output.schema
 AVRO_VALUE_INPUT_SCHEMA=pydoop.mapreduce.avro.value.input.schema
 AVRO_VALUE_OUTPUT_SCHEMA=pydoop.mapreduce.avro.value.output.schema
+PIPES_EXTERNALSPLITS_URI=pydoop.mapreduce.pipes.externalsplits.uri

--- a/pydoop/mapreduce/pipes.py
+++ b/pydoop/mapreduce/pipes.py
@@ -53,8 +53,6 @@ PSTATS_DIR = "PYDOOP_PSTATS_DIR"
 PSTATS_FMT = "PYDOOP_PSTATS_FMT"
 DEFAULT_PSTATS_FMT = "%s_%05d_%s"  # task_type, task_id, random suffix
 
-EXTERNALSPLITS_URI_KEY = "pydoop.mapreduce.pipes.externalsplits.uri"
-
 INT_WRITABLE_FMT = ">i"
 INT_WRITABLE_SIZE = struct.calcsize(INT_WRITABLE_FMT)
 
@@ -162,7 +160,7 @@ class TaskContext(api.Context):
         if raw:
             return self._raw_split
         if not self._input_split:
-            if EXTERNALSPLITS_URI_KEY in self._job_conf:
+            if config.PIPES_EXTERNALSPLITS_URI in self._job_conf:
                 self._input_split = OpaqueSplit.frombuffer(self._raw_split)
             else:
                 self._input_split = FileSplit.frombuffer(self._raw_split)

--- a/src/it/crs4/pydoop/mapreduce/pipes/PipesNonJavaInputFormat.java
+++ b/src/it/crs4/pydoop/mapreduce/pipes/PipesNonJavaInputFormat.java
@@ -20,6 +20,7 @@ package it.crs4.pydoop.mapreduce.pipes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
@@ -50,13 +51,11 @@ import org.apache.hadoop.util.ReflectionUtils;
 class PipesNonJavaInputFormat
     extends InputFormat<FloatWritable, NullWritable> {
 
-  public static final String EXTERNAL_SPLITS_URI =
-      "pydoop.mapreduce.pipes.externalsplits.uri";
-
   public List<InputSplit> getSplits(JobContext context)
       throws IOException, InterruptedException {
+    Properties props = Submitter.getPydoopProperties();
     Configuration conf = context.getConfiguration();
-    String uri = conf.get(EXTERNAL_SPLITS_URI);
+    String uri = conf.get(props.getProperty("PIPES_EXTERNALSPLITS_URI"));
     if (uri != null) {
       return getOpaqueSplits(conf, uri);
     } else {

--- a/test/mapreduce/it/crs4/pydoop/mapreduce/pipes/OpaqueRoundtrip.java
+++ b/test/mapreduce/it/crs4/pydoop/mapreduce/pipes/OpaqueRoundtrip.java
@@ -21,6 +21,7 @@ package it.crs4.pydoop.mapreduce.pipes;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
 
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -52,8 +53,9 @@ public class OpaqueRoundtrip {
     TaskAttemptID taID = new TaskAttemptID(taskId, 0);
     Job job = Job.getInstance(new Configuration());
     job.setJobID(jobId);
+    Properties props = Submitter.getPydoopProperties();
     Configuration conf = job.getConfiguration();
-    conf.set(PipesNonJavaInputFormat.EXTERNAL_SPLITS_URI, inUri);
+    conf.set(props.getProperty("PIPES_EXTERNALSPLITS_URI"), inUri);
     TaskAttemptContextImpl ctx = new TaskAttemptContextImpl(conf, taID);
     PipesNonJavaInputFormat iformat = new PipesNonJavaInputFormat();
     List<InputSplit> splits = iformat.getSplits(ctx);


### PR DESCRIPTION
Adds `pydoop.mapreduce.pipes.externalsplits.uri` to the properties file, so that Java and Python can share a single definition.