### PR TITLE
Update pydoop-client image

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -1,12 +1,12 @@
-FROM crs4/pydoop-client-base
-MAINTAINER simone.leo@crs4.it
+ARG hadoop_version=3.2.0
+ARG python_version=3.6
+
+FROM crs4/pydoop-client-base:${hadoop_version}-${python_version}
 
 COPY . /build/pydoop
 WORKDIR /build/pydoop
 
-RUN for v in 2 3; do \
-      pip${v} install --no-cache-dir --upgrade -r requirements.txt && \
-      python${v} setup.py build && \
-      python${v} setup.py install --skip-build && \
-      python${v} setup.py clean; \
-    done
+RUN ${PYTHON} -m pip install --no-cache-dir --upgrade -r requirements.txt \
+    && ${PYTHON} setup.py build \
+    && ${PYTHON} setup.py install --skip-build \
+    && ${PYTHON} setup.py clean

--- a/docker/Dockerfile.client-base
+++ b/docker/Dockerfile.client-base
@@ -1,34 +1,17 @@
-FROM centos:7
-MAINTAINER simone.leo@crs4.it
+ARG hadoop_version=3.2.0
+ARG python_version=3.6
 
-ARG HADOOP_VERSION=3.0.3
-ARG JAVA_VERSION=1.8.0
-
+FROM crs4/hadoopclient:${hadoop_version}-ubuntu
+ARG python_version
+ENV PYTHON=python${python_version}
+RUN v=$([ ${python_version%%.*} -eq 3 ] && echo 3 || echo) \
+    && apt -y update && apt -y install \
+      openjdk-8-jdk \
+      python${python_version}-dev \
+      python${v}-pip \
+    && apt clean && rm -rf /var/lib/apt-lists/* \
+    && ${PYTHON} -m pip install --no-cache-dir --upgrade pip
 ENV HADOOP_HOME=/opt/hadoop
-ENV JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-openjdk
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-
-COPY install_hadoop.sh /
-
-RUN echo "assumeyes=1" >> /etc/yum.conf && \
-    yum install https://centos7.iuscommunity.org/ius-release.rpm && \
-    yum update && \
-    yum install \
-      java-${JAVA_VERSION}-openjdk-devel \
-      gcc \
-      gcc-c++ \
-      make \
-      python-devel \
-      python-pip \
-      python36u-devel \
-      python36u-pip && \
-    yum clean all && \
-    bash /install_hadoop.sh && \
-    echo "export JAVA_HOME=\"/usr/lib/jvm/java-${JAVA_VERSION}-openjdk\"" > /etc/profile.d/java.sh && \
-    echo "export PATH=\"${HADOOP_HOME}/bin:${HADOOP_HOME}/sbin:${PATH}\"" > /etc/profile.d/hadoop.sh && \
-    ln -rs /usr/bin/python3.6 /usr/bin/python3 && \
-    ln -rs /usr/bin/pip3.6 /usr/bin/pip3 && \
-    for v in 2 3; do \
-      pip${v} install --no-cache-dir --upgrade pip; \
-    done
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8


### PR DESCRIPTION
Rebased on top of `crs4/hadoopclient`. At some point, this should evolve into a "production" Pydoop image with a minimal setup (no extras, no source directory, etc.). We might also consider moving it to a separate repo.