### PR TITLE
docs: Fix a few typos

### DIFF
--- a/dev_tools/docker/cluster.rst
+++ b/dev_tools/docker/cluster.rst
@@ -167,7 +167,7 @@ Log in on the client, install pydoop and run the tests::
 Details
 -------
 
-Boostrap strategy
+Bootstrap strategy
 ;;;;;;;;;;;;;;;;;
 
 The main synchronization issues are:
@@ -180,7 +180,7 @@ The main synchronization issues are:
    pre-condition to service firing up.
 
 
-The boostrap strategy is as follows.
+The bootstrap strategy is as follows.
 
  #. There is an external mechanism -- here is the script
     ``../scripts/share_etc_hosts.py``, but it should really be integrated in
@@ -189,19 +189,19 @@ The boostrap strategy is as follows.
     that can talk to the docker server to be sure that we got all the nodes
     involved.
 
- #. We have a zookeper node that is guaranteed to be fired before any other
+ #. We have a zookeeper node that is guaranteed to be fired before any other
     service by having all other nodes linked to it in the docker-compose.yml
     file.
 
- #. We have an auxiliary service, boostrap, that is in charge of orchestrating
-    the system boostrap.
+ #. We have an auxiliary service, bootstrap, that is in charge of orchestrating
+    the system bootstrap.
 
- #. The expected boostrap workflow is as follows.
+ #. The expected bootstrap workflow is as follows.
 
    a. docker-compose starts
-   b. all services (except zookeper and bootstrap) wait until
+   b. all services (except zookeeper and bootstrap) wait until
       ``zookeeper:/<servicename>`` is set to ``boot``
-   c. boostrap then does the following:
+   c. bootstrap then does the following:
       
       1. waits until its /etc/hosts  has been changed;
       2. sets ``/{namenode,datanode}`` to boot;

--- a/docs/examples/sequence_file.rst
+++ b/docs/examples/sequence_file.rst
@@ -10,7 +10,7 @@ basically have two options:
    you need to process
 #. convert your data to Hadoop's standard ``SequenceFile`` format.
 
-To write sequence files with Pydoop, set the ouput format and the
+To write sequence files with Pydoop, set the output format and the
 compression type as follows::
 
   pydoop submit \

--- a/pydoop/app/submit.py
+++ b/pydoop/app/submit.py
@@ -227,7 +227,7 @@ class PydoopSubmitter(object):
             env['PYTHONPATH'] = ':'.join([
                 self.__cache_archive_link(ar) for ar in self.args.python_zip
             ] + [env['PYTHONPATH']])
-        # Note that we have to explicitely put the working directory
+        # Note that we have to explicitly put the working directory
         # in the python path otherwise it will miss cached modules and
         # packages.
         env['PYTHONPATH'] = "${PWD}:" + env['PYTHONPATH']

--- a/pydoop/avrolib.py
+++ b/pydoop/avrolib.py
@@ -82,7 +82,7 @@ class SeekableDataFileReader(DataFileReader):
         if offset <= 0:  # FIXME what is a negative offset??
             f.seek(0)
             self._block_count = 0
-            self._read_header()  # FIXME we can't extimate how big it is...
+            self._read_header()  # FIXME we can't estimate how big it is...
             return
         sm = self.sync_marker
         sml = len(sm)

--- a/src/libhdfs/jni_helper.h
+++ b/src/libhdfs/jni_helper.h
@@ -146,7 +146,7 @@ jthrowable hadoopConfSetStr(JNIEnv *env, jobject jConfiguration,
  * @param valueName         The name of the enum value
  * @param out               (out param) on success, a local reference to an
  *                          instance of the enum object.  (Since Java enums are
- *                          singletones, this is also the only instance.)
+ *                          singletons, this is also the only instance.)
  *
  * @return                  NULL on success; exception otherwise
  */


### PR DESCRIPTION
There are small typos in:
- dev_tools/docker/cluster.rst
- docs/examples/sequence_file.rst
- pydoop/app/submit.py
- pydoop/avrolib.py
- src/libhdfs/jni_helper.h

Fixes:
- Should read `bootstrap` rather than `boostrap`.
- Should read `zookeeper` rather than `zookeper`.
- Should read `singletons` rather than `singletones`.
- Should read `output` rather than `ouput`.
- Should read `explicitly` rather than `explicitely`.
- Should read `estimate` rather than `extimate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md